### PR TITLE
chore: 🔧 add pipeline and pink-gremlins to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/telemetry-team
+* @honeycombio/pink-gremlins @honeycombio/pipeline
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
- Adds `pink-gremlins` and `pipeline` teams as CODEOWNERS

## Short description of the changes
- Added teams to CODEOWNERS

## How to verify that this has the expected result
- Both teams will be tagged in PRs