### PR TITLE
feat:  ✨ Pull in base OTel WebSDK

### DIFF
--- a/examples/hello-world-web/index.js
+++ b/examples/hello-world-web/index.js
@@ -1,9 +1,17 @@
 import { WebSDK } from '@honeycombio/opentelemetry-web';
 import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api';
+import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+
 const main = () => {
-  console.log('Hello from the example app');
+  // Set OTel to log in Debug mode
   diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
-  const sdk = new WebSDK();
+
+  // Initialize base OTel WebSDK
+  const sdk = new WebSDK({
+    instrumentations: [getWebAutoInstrumentations()], // add auto-instrumentation
+    traceExporter: new ConsoleSpanExporter(), // log spans to the console
+  });
   sdk.start();
 };
 

--- a/examples/hello-world-web/index.js
+++ b/examples/hello-world-web/index.js
@@ -1,7 +1,10 @@
 import { WebSDK } from '@honeycombio/opentelemetry-web';
+import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api';
 const main = () => {
   console.log('Hello from the example app');
-  new WebSDK();
+  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+  const sdk = new WebSDK();
+  sdk.start();
 };
 
 main();

--- a/examples/hello-world-web/package-lock.json
+++ b/examples/hello-world-web/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@honeycombio/opentelemetry-web": "file:../../dist/src"
+        "@honeycombio/opentelemetry-web": "file:../../dist/src",
+        "@opentelemetry/auto-instrumentations-web": "^0.34.0"
       },
       "devDependencies": {
         "esbuild": "0.19.8",
@@ -373,6 +374,195 @@
       "resolved": "../../dist/src",
       "link": true
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
+      "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/auto-instrumentations-web": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-web/-/auto-instrumentations-web-0.34.0.tgz",
+      "integrity": "sha512-9kF4huaKvEU7s5eet4xKLTIyRxhxKX80/YSWRjrHAT0FR0T8ZFxMyI1CdCsP4reYgA8+KJcXSdI/7xw4wdsVdA==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation-document-load": "^0.34.0",
+        "@opentelemetry/instrumentation-fetch": "^0.45.1",
+        "@opentelemetry/instrumentation-user-interaction": "^0.34.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.45.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "zone.js": "0.11.4"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.45.1.tgz",
+      "integrity": "sha512-V1Cr0g8hSg35lpW3G/GYVZurrhHrQZJdmP68WyJ83f1FDn3iru+/Vnlto9kiOSm7PHhW+pZGdb9Fbv+mkQ31CA==",
+      "dependencies": {
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "1.4.2",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-document-load": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-document-load/-/instrumentation-document-load-0.34.0.tgz",
+      "integrity": "sha512-KvhQ7UDhHu/MCNeqm8rgeB82aM8D2sLYHPX65mamY9iJiXTe6cWzobZOgej5UjZqik8AE+z6mdiNupBiD7Y8lg==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/sdk-trace-base": "^1.0.0",
+        "@opentelemetry/sdk-trace-web": "^1.15.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fetch": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.45.1.tgz",
+      "integrity": "sha512-BcLXMlZmGN5islwT+B1hHmgrizZbA7MgTUHhlvwLkZpAmlDeCBUdr779q2iOpxixD2AcpUTQ1RY54JArCZIB7w==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/instrumentation": "0.45.1",
+        "@opentelemetry/sdk-trace-web": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-user-interaction": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-user-interaction/-/instrumentation-user-interaction-0.34.0.tgz",
+      "integrity": "sha512-QN/8IwnoAjI92Mtc4vnatI3x+KSAoGOpILhVlm9dyGu9PtXJSdYpGqc9PZleJx4SKuLmVjjktSZTQllXNqgU5A==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/sdk-trace-web": "^1.8.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "zone.js": "0.11.4"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-xml-http-request": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.45.1.tgz",
+      "integrity": "sha512-gwX55apcB4d+2OpZsOEtct+eUAvtZ9wT8IyZVbzZyN471vSePacKNrGbQr8uFlyioPj+IAS/izv+LJyqw6PNxA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/instrumentation": "0.45.1",
+        "@opentelemetry/sdk-trace-web": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.18.1.tgz",
+      "integrity": "sha512-tRHfDxN5dO+nop78EWJpzZwHsN1ewrZRVVwo03VJa3JQZxToRDH29/+MB24+yoa+IArerdr7INFJiX/iN4gjqg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/resources": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-web": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.18.1.tgz",
+      "integrity": "sha512-WN30vxy4NY8TqFWuICXaPXjBdy6A5kDhxOqp4NfhqXfpcWWT0GqSgv05Q42quWYOFgaulnmPRRJwxzAdhBliLQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/sdk-trace-base": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/shimmer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.5.tgz",
+      "integrity": "sha512-9Hp0ObzwwO57DpLFF0InUjUm/II8GmKAvzbefxQTihCb7KI6yc9yzf0nLc4mVdby5N4DRCgQM2wCup9KTieeww=="
+    },
     "node_modules/@zeit/schemas": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.29.0.tgz",
@@ -390,6 +580,25 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/ajv": {
@@ -625,6 +834,11 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
+    },
     "node_modules/cli-boxes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
@@ -836,6 +1050,14 @@
         "punycode": "^1.3.2"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -857,6 +1079,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -866,11 +1099,33 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
+    },
+    "node_modules/is-core-module": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dependencies": {
+        "hasown": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
@@ -944,6 +1199,17 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -1000,6 +1266,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -1066,6 +1337,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "2.2.1",
@@ -1134,11 +1410,75 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
+      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/serve": {
       "version": "14.2.1",
@@ -1223,6 +1563,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -1290,6 +1635,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "peer": true
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -1385,6 +1747,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/zone.js": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.4.tgz",
+      "integrity": "sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
       }
     }
   },
@@ -1546,6 +1922,127 @@
     "@honeycombio/opentelemetry-web": {
       "version": "file:../../dist/src"
     },
+    "@opentelemetry/api": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
+      "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
+      "peer": true
+    },
+    "@opentelemetry/auto-instrumentations-web": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-web/-/auto-instrumentations-web-0.34.0.tgz",
+      "integrity": "sha512-9kF4huaKvEU7s5eet4xKLTIyRxhxKX80/YSWRjrHAT0FR0T8ZFxMyI1CdCsP4reYgA8+KJcXSdI/7xw4wdsVdA==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation-document-load": "^0.34.0",
+        "@opentelemetry/instrumentation-fetch": "^0.45.1",
+        "@opentelemetry/instrumentation-user-interaction": "^0.34.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.45.1"
+      }
+    },
+    "@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "requires": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      }
+    },
+    "@opentelemetry/instrumentation": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.45.1.tgz",
+      "integrity": "sha512-V1Cr0g8hSg35lpW3G/GYVZurrhHrQZJdmP68WyJ83f1FDn3iru+/Vnlto9kiOSm7PHhW+pZGdb9Fbv+mkQ31CA==",
+      "requires": {
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "1.4.2",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      }
+    },
+    "@opentelemetry/instrumentation-document-load": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-document-load/-/instrumentation-document-load-0.34.0.tgz",
+      "integrity": "sha512-KvhQ7UDhHu/MCNeqm8rgeB82aM8D2sLYHPX65mamY9iJiXTe6cWzobZOgej5UjZqik8AE+z6mdiNupBiD7Y8lg==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/sdk-trace-base": "^1.0.0",
+        "@opentelemetry/sdk-trace-web": "^1.15.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
+      }
+    },
+    "@opentelemetry/instrumentation-fetch": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.45.1.tgz",
+      "integrity": "sha512-BcLXMlZmGN5islwT+B1hHmgrizZbA7MgTUHhlvwLkZpAmlDeCBUdr779q2iOpxixD2AcpUTQ1RY54JArCZIB7w==",
+      "requires": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/instrumentation": "0.45.1",
+        "@opentelemetry/sdk-trace-web": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      }
+    },
+    "@opentelemetry/instrumentation-user-interaction": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-user-interaction/-/instrumentation-user-interaction-0.34.0.tgz",
+      "integrity": "sha512-QN/8IwnoAjI92Mtc4vnatI3x+KSAoGOpILhVlm9dyGu9PtXJSdYpGqc9PZleJx4SKuLmVjjktSZTQllXNqgU5A==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/sdk-trace-web": "^1.8.0"
+      }
+    },
+    "@opentelemetry/instrumentation-xml-http-request": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.45.1.tgz",
+      "integrity": "sha512-gwX55apcB4d+2OpZsOEtct+eUAvtZ9wT8IyZVbzZyN471vSePacKNrGbQr8uFlyioPj+IAS/izv+LJyqw6PNxA==",
+      "requires": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/instrumentation": "0.45.1",
+        "@opentelemetry/sdk-trace-web": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      }
+    },
+    "@opentelemetry/resources": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "requires": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      }
+    },
+    "@opentelemetry/sdk-trace-base": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.18.1.tgz",
+      "integrity": "sha512-tRHfDxN5dO+nop78EWJpzZwHsN1ewrZRVVwo03VJa3JQZxToRDH29/+MB24+yoa+IArerdr7INFJiX/iN4gjqg==",
+      "requires": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/resources": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      }
+    },
+    "@opentelemetry/sdk-trace-web": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.18.1.tgz",
+      "integrity": "sha512-WN30vxy4NY8TqFWuICXaPXjBdy6A5kDhxOqp4NfhqXfpcWWT0GqSgv05Q42quWYOFgaulnmPRRJwxzAdhBliLQ==",
+      "requires": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/sdk-trace-base": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      }
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA=="
+    },
+    "@types/shimmer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.5.tgz",
+      "integrity": "sha512-9Hp0ObzwwO57DpLFF0InUjUm/II8GmKAvzbefxQTihCb7KI6yc9yzf0nLc4mVdby5N4DRCgQM2wCup9KTieeww=="
+    },
     "@zeit/schemas": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.29.0.tgz",
@@ -1561,6 +2058,17 @@
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
       }
+    },
+    "acorn": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w=="
+    },
+    "acorn-import-assertions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "requires": {}
     },
     "ajv": {
       "version": "8.11.0",
@@ -1720,6 +2228,11 @@
           }
         }
       }
+    },
+    "cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
     "cli-boxes": {
       "version": "3.0.0",
@@ -1889,6 +2402,11 @@
         "punycode": "^1.3.2"
       }
     },
+    "function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -1901,17 +2419,44 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
+    "hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
+    },
     "human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
+    "import-in-the-middle": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "requires": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
+    },
+    "is-core-module": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "requires": {
+        "hasown": "^2.0.0"
+      }
     },
     "is-docker": {
       "version": "2.2.1",
@@ -1958,6 +2503,14 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -1999,6 +2552,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
+    },
+    "module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
     },
     "ms": {
       "version": "2.0.0",
@@ -2047,6 +2605,11 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "2.2.1",
@@ -2103,11 +2666,54 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
+    "require-in-the-middle": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
+      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
+      "requires": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "requires": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "serve": {
       "version": "14.2.1",
@@ -2176,6 +2782,11 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -2222,6 +2833,17 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "peer": true
     },
     "type-fest": {
       "version": "2.19.0",
@@ -2289,6 +2911,20 @@
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
         "strip-ansi": "^7.0.1"
+      }
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "zone.js": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.4.tgz",
+      "integrity": "sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.0.0"
       }
     }
   }

--- a/examples/hello-world-web/package.json
+++ b/examples/hello-world-web/package.json
@@ -11,7 +11,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@honeycombio/opentelemetry-web": "file:../../dist/src"
+    "@honeycombio/opentelemetry-web": "file:../../dist/src",
+    "@opentelemetry/auto-instrumentations-web": "^0.34.0"
   },
   "devDependencies": {
     "esbuild": "0.19.8",

--- a/src/base-otel-sdk.ts
+++ b/src/base-otel-sdk.ts
@@ -1,33 +1,174 @@
-import { WebSDKConfiguration } from './types';
-// import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+// This code will eventually be packaged upstream into a WebSDK package.
+// Once it is released as a package, this distro will depend directly on the upstream package.
+// https://github.com/open-telemetry/opentelemetry-js/pull/4325
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ContextManager, TextMapPropagator } from '@opentelemetry/api';
 import {
-  WebTracerProvider,
+  InstrumentationOption,
+  registerInstrumentations,
+} from '@opentelemetry/instrumentation';
+import {
+  Detector,
+  DetectorSync,
+  detectResourcesSync,
+  IResource,
+  browserDetector,
+  Resource,
+  ResourceDetectionConfig,
+} from '@opentelemetry/resources';
+import {
   BatchSpanProcessor,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import {
+  WebTracerConfig,
+  WebTracerProvider,
 } from '@opentelemetry/sdk-trace-web';
-// import { ZoneContextManager } from '@opentelemetry/context-zone';
-import { Resource } from '@opentelemetry/resources';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import { registerInstrumentations } from '@opentelemetry/instrumentation';
-import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+import { WebSDKConfiguration } from './types';
+// import { SessionIdSpanProcessor } from './SessionIdSpanProcessor';
+
+/** This class represents everything needed to register a fully configured OpenTelemetry Web SDK */
 
 export class WebSDK {
+  private _tracerProviderConfig?: {
+    tracerConfig: WebTracerConfig;
+    spanProcessor: SpanProcessor;
+    contextManager?: ContextManager;
+    textMapPropagator?: TextMapPropagator;
+  };
+  private _instrumentations: InstrumentationOption[];
+
+  private _resource: IResource;
+  private _resourceDetectors: Array<Detector | DetectorSync>;
+
+  private _autoDetectResources: boolean;
+
+  private _tracerProvider?: WebTracerProvider;
+  private _serviceName?: string;
+
+  private _disabled?: boolean;
+
   /**
    * Create a new Web SDK instance
    */
   public constructor(configuration: Partial<WebSDKConfiguration> = {}) {
-    diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
-    const provider = new WebTracerProvider({
-      resource: new Resource({
-        [SemanticResourceAttributes.SERVICE_NAME]: configuration.serviceName,
-      }),
-    });
+    this._resource = configuration.resource ?? new Resource({});
+    this._resourceDetectors = configuration.resourceDetectors ?? [
+      browserDetector,
+    ];
 
-    provider.addSpanProcessor(
-      new BatchSpanProcessor(configuration.traceExporter!),
-    );
+    this._serviceName = configuration.serviceName;
+
+    this._autoDetectResources = configuration.autoDetectResources ?? true;
+
+    if (configuration.spanProcessor || configuration.traceExporter) {
+      const tracerProviderConfig: WebTracerConfig = {};
+
+      if (configuration.sampler) {
+        tracerProviderConfig.sampler = configuration.sampler;
+      }
+      if (configuration.spanLimits) {
+        tracerProviderConfig.spanLimits = configuration.spanLimits;
+      }
+      if (configuration.idGenerator) {
+        tracerProviderConfig.idGenerator = configuration.idGenerator;
+      }
+
+      const spanProcessor =
+        configuration.spanProcessor ??
+        new BatchSpanProcessor(configuration.traceExporter!);
+
+      this._tracerProviderConfig = {
+        tracerConfig: tracerProviderConfig,
+        spanProcessor,
+        contextManager: configuration.contextManager,
+        textMapPropagator: configuration.textMapPropagator,
+      };
+    }
+
+    let instrumentations: InstrumentationOption[] = [];
+    if (configuration.instrumentations) {
+      instrumentations = configuration.instrumentations;
+    }
+    this._instrumentations = instrumentations;
+  }
+
+  /**
+   * Call this method to construct SDK components and register them with the OpenTelemetry API.
+   */
+  public start(): void {
+    if (this._disabled) {
+      return;
+    }
 
     registerInstrumentations({
-      instrumentations: configuration.instrumentations,
+      instrumentations: this._instrumentations,
     });
+
+    if (this._autoDetectResources) {
+      const internalConfig: ResourceDetectionConfig = {
+        detectors: this._resourceDetectors,
+      };
+      this._resource = this._resource.merge(
+        detectResourcesSync(internalConfig),
+      );
+    }
+
+    this._resource =
+      this._serviceName === undefined
+        ? this._resource
+        : this._resource.merge(
+            new Resource({
+              [SemanticResourceAttributes.SERVICE_NAME]: this._serviceName,
+            }),
+          );
+
+    const tracerProvider = new WebTracerProvider({
+      ...this._tracerProviderConfig?.tracerConfig,
+      resource: this._resource,
+    });
+
+    this._tracerProvider = tracerProvider;
+
+    if (this._tracerProviderConfig) {
+      tracerProvider.addSpanProcessor(this._tracerProviderConfig.spanProcessor);
+    }
+
+    tracerProvider.register({
+      contextManager: this._tracerProviderConfig?.contextManager,
+      propagator: this._tracerProviderConfig?.textMapPropagator,
+    });
+
+    // add processor for adding the sessionId attribute
+    // tracerProvider.addSpanProcessor(new SessionIdSpanProcessor());
+  }
+
+  public shutdown(): Promise<void> {
+    const promises: Promise<unknown>[] = [];
+    if (this._tracerProvider) {
+      promises.push(this._tracerProvider.shutdown());
+    }
+
+    return (
+      Promise.all(promises)
+        // return void instead of the array from Promise.all
+        .then(() => {})
+    );
   }
 }

--- a/src/base-otel-sdk.ts
+++ b/src/base-otel-sdk.ts
@@ -41,7 +41,6 @@ import {
 } from '@opentelemetry/sdk-trace-web';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { WebSDKConfiguration } from './types';
-// import { SessionIdSpanProcessor } from './SessionIdSpanProcessor';
 
 /** This class represents everything needed to register a fully configured OpenTelemetry Web SDK */
 
@@ -154,9 +153,6 @@ export class WebSDK {
       contextManager: this._tracerProviderConfig?.contextManager,
       propagator: this._tracerProviderConfig?.textMapPropagator,
     });
-
-    // add processor for adding the sessionId attribute
-    // tracerProvider.addSpanProcessor(new SessionIdSpanProcessor());
   }
 
   public shutdown(): Promise<void> {

--- a/src/base-otel-sdk.ts
+++ b/src/base-otel-sdk.ts
@@ -41,6 +41,7 @@ import {
 } from '@opentelemetry/sdk-trace-web';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { WebSDKConfiguration } from './types';
+import { SessionIdSpanProcessor } from './session-id-span-processor';
 
 /** This class represents everything needed to register a fully configured OpenTelemetry Web SDK */
 
@@ -153,6 +154,9 @@ export class WebSDK {
       contextManager: this._tracerProviderConfig?.contextManager,
       propagator: this._tracerProviderConfig?.textMapPropagator,
     });
+
+    // add processor for adding the sessionId attribute
+    tracerProvider.addSpanProcessor(new SessionIdSpanProcessor());
   }
 
   public shutdown(): Promise<void> {

--- a/src/session-id-span-processor.ts
+++ b/src/session-id-span-processor.ts
@@ -1,0 +1,67 @@
+// This code will eventually be packaged upstream into a WebSDK package.
+// Once it is released as a package, this distro will depend directly on the upstream package.
+// https://github.com/open-telemetry/opentelemetry-js/pull/4325
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Context } from '@opentelemetry/api';
+import {
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+
+const SESSION_ID_BYTES = 16;
+const SHARED_CHAR_CODES_ARRAY = Array(32);
+
+export class SessionIdSpanProcessor implements SpanProcessor {
+  private _sessionId;
+  private _idGenerator = getIdGenerator(SESSION_ID_BYTES);
+
+  constructor() {
+    this._sessionId = this._idGenerator();
+  }
+
+  onStart(span: Span, parentContext: Context): void {
+    span.setAttribute('session.id', this._sessionId);
+  }
+
+  onEnd(span: ReadableSpan): void {}
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function getIdGenerator(bytes: number): () => string {
+  return function generateId() {
+    for (let i = 0; i < bytes * 2; i++) {
+      SHARED_CHAR_CODES_ARRAY[i] = Math.floor(Math.random() * 16) + 48;
+      // valid hex characters in the range 48-57 and 97-102
+      if (SHARED_CHAR_CODES_ARRAY[i] >= 58) {
+        SHARED_CHAR_CODES_ARRAY[i] += 39;
+      }
+    }
+    return String.fromCharCode.apply(
+      null,
+      SHARED_CHAR_CODES_ARRAY.slice(0, bytes * 2),
+    );
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,22 @@
+// This code will eventually be packaged upstream into a WebSDK package.
+// Once it is released as a package, this distro will depend directly on the upstream package.
+// https://github.com/open-telemetry/opentelemetry-js/pull/4325
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { ContextManager } from '@opentelemetry/api';
 import { TextMapPropagator } from '@opentelemetry/api';
 import { InstrumentationOption } from '@opentelemetry/instrumentation';


### PR DESCRIPTION
## Which problem is this PR solving?
This PR pulls in the code that will eventually become the OpenTelemetry WebSDK. For now we're using all the code from the [draft PR](https://github.com/open-telemetry/opentelemetry-js/pull/4325) that is up so it is subject to change, we're not worried about it changing too much because it is very similar to the NodeSDK which is a released package. 

The main new piece of this SDK is the `SpanIdSpanProcessor`, ~I have chosen to leave this component out for now because it is pretty unstable and undefined and [still depends on `Buffer` which is a Node-only API](https://github.com/open-telemetry/opentelemetry-js/pull/4325/files#diff-27a5bf158857e4404f443ccb5b11e07c4486203a76f9953e1316167cf5723f01R22). We can pull this in as it becomes more stable as it will be an additive change.~ Nevermind, I figured out how to make it browser friendly because there was prior art in upstream OTel for this with trace and span IDs, this is likely what it will look like so I feel comfortable pulling it in for now.

## Short description of the changes
- Pull in WebSDK code and types
- The distro will emit `session.id` 🎉 
- Update example to use the WebSDK
- Update example to emit traces

## How to verify that this has the expected result
1. Build the project, in the root directory run: `npm run build`
2. Change directories to the example app: `cd examples/hello-world-web`
3. Build the example app: `npm run build`
4. Run the example app: `npm start`
5. Go to http://localhost:3000 in the browser
6. Open the console tab, you should see OTel debug messages as well as document load traces logged to the console.
