### PR TITLE
chore: 🔧 Add github action to add issues to asana

### DIFF
--- a/.github/workflows/gh-issue-to-asana.yml
+++ b/.github/workflows/gh-issue-to-asana.yml
@@ -15,7 +15,6 @@ jobs:
           asana-workspace-id: ${{ secrets.ASANA_WORKSPACE_ID }}
           asana-project-id: ${{ secrets.ASANA_PROJECT_ID }}
           asana-section-id: ${{ secrets.ASANA_SECTION_ID }}
-          # asana-tags: '["1203366051961930", "1170327382493643"]' # adds the tags interrupt and oncall
           asana-task-name: '${{ github.event.repository.name }}: ${{ github.event.issue.title }}'
           asana-task-description: |
             ${{ github.event.issue.body }}

--- a/.github/workflows/gh-issue-to-asana.yml
+++ b/.github/workflows/gh-issue-to-asana.yml
@@ -1,0 +1,22 @@
+name: Sync Github Issue to Asana
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  create-asana-task:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create Asana task
+        uses: honeycombio/gha-create-asana-task@v1.0.1
+        with:
+          asana-secret: ${{ secrets.ASANA_SECRET }}
+          asana-workspace-id: ${{ secrets.ASANA_WORKSPACE_ID }}
+          asana-project-id: ${{ secrets.ASANA_PROJECT_ID }}
+          asana-section-id: ${{ secrets.ASANA_SECTION_ID }}
+          # asana-tags: '["1203366051961930", "1170327382493643"]' # adds the tags interrupt and oncall
+          asana-task-name: '${{ github.event.repository.name }}: ${{ github.event.issue.title }}'
+          asana-task-description: |
+            ${{ github.event.issue.body }}
+            source: https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${{ github.event.issue.number }}


### PR DESCRIPTION
## Which problem is this PR solving?
Automates creating Asana tickets for issues opened on this project. This will help us keep track of the web distro work in GH issues so that there's a good history of that once the repo is public but will also preserve our team's workflow of keeping track of work in Asana.

## Short description of the changes
- Added a GitHub action that creates an Asana task on our team board whenever a new issue is created on this repo.
- Added Asana secrets to this repo 
<img width="216" alt="Screenshot 2023-12-06 at 11 58 18 AM" src="https://github.com/honeycombio/honeycomb-opentelemetry-web/assets/8810222/29c57c27-1790-4c2d-8776-b7b7c0f58182">

## How to verify that this has the expected result
I don't think we can test this until this is merged to main unfortunately 😭. Instead of using a PAT, I want to test if our org wide `ASANA_SECRET` will work so that I can avoid generating a PAT linked to my own Asana account. If that doesn't work I'll make a follow up PR to fix it.
