### PR TITLE
fix: 🐛 Use Asana PAT token

### DIFF
--- a/.github/workflows/gh-issue-to-asana.yml
+++ b/.github/workflows/gh-issue-to-asana.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Create Asana task
         uses: honeycombio/gha-create-asana-task@v1.0.1
         with:
-          asana-secret: ${{ secrets.ASANA_SECRET }}
+          asana-secret: ${{ secrets.ASANA_PAT }}
           asana-workspace-id: ${{ secrets.ASANA_WORKSPACE_ID }}
           asana-project-id: ${{ secrets.ASANA_PROJECT_ID }}
           asana-section-id: ${{ secrets.ASANA_SECTION_ID }}


### PR DESCRIPTION
## Which problem is this PR solving?
In #4 I was hoping to use the org wide Asana secret as the token but it seems like a PAT token linked to my account is the way to go about this after seeing the [auth failing](https://github.com/honeycombio/honeycomb-opentelemetry-web/actions/runs/7117859157) when I tried to test the issue creation action

## Short description of the changes
- `ASANA_SECRET` --> `ASANA_PAT`
- Add an Asana PAT token to GitHub repo secrets

## How to verify that this has the expected result
Again we'll have to merge to main before knowing this will work, it seems likely though because other projects are set up similarly.
