### PR TITLE
maint: 📕 add browser resource & honeycomb distro fields to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ The SDK adds these fields to all telemetry:
 |------|--------|---------|-------------|---------|
 | user_agent.original | [stable](https://github.com/scheler/opentelemetry-specification/blob/browser-events/specification/resource/semantic_conventions/browser.md) | static | window.user_agent | `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36` |
 | browser.height | planned | per-span | `[window.innerHeight](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerHeight)`, the height of the layout viewport in pixels | 287 |
+| browser.brands | stable | static | [NavigatorUAData: brands](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/brands) | ["Not_A Brand 8", "Chromium 120", "Google Chrome 120"] |
+| browser.platform | stable | static | [NavigatorUAData: platform](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/platform) | "Windows" |
+| browser.mobile | stable | static | [NavigatorUAData: mobile](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/mobile) | true |
+| browser.language | stable | static | [Navigator: language](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language) | "fr-FR" |
+| honeycomb.distro.version | stable | static | package version | "1.2.3" |
+| honeycomb.distro.runtime_version | stable | static | | "browser"
 
 Static fields are added to the [Resource](https://opentelemetry.io/docs/concepts/resources/), so they are same for every span emitted for the loaded page.
 


### PR DESCRIPTION
## Short description of the changes
Follow up to #23  — adds browser resource & honeycomb distro fields to [readme table](https://github.com/honeycombio/honeycomb-opentelemetry-web/blob/14b15ea05940fc38253fdfbad6f34cd842652199/README.md#fields-emitted)

