### PR TITLE
maint: 🔧  add `mergeResources` util

### DIFF
--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -2,11 +2,15 @@ import { WebSDK } from './base-otel-sdk';
 import { HoneycombOptions } from './types';
 import { configureHoneycombHttpJsonTraceExporter } from './http-json-trace-exporter';
 import { configureHoneycombResource } from './honeycomb-resource';
+import { mergeResources } from './merge-resources';
 
 export class HoneycombWebSDK extends WebSDK {
   constructor(options?: HoneycombOptions) {
     super({
-      resource: configureHoneycombResource(options),
+      resource: mergeResources([
+        configureHoneycombResource(),
+        options?.resource,
+      ]),
       traceExporter: configureHoneycombHttpJsonTraceExporter(options),
 
       ...options,

--- a/src/merge-resources.ts
+++ b/src/merge-resources.ts
@@ -1,0 +1,15 @@
+import { Resource } from '@opentelemetry/resources';
+
+/* Takes an array of resources and merges into one mega-resource */
+export function mergeResources(
+  resources: Array<Resource | null | undefined>,
+): Resource {
+  let mergedResources = resources[0] || new Resource({});
+
+  for (let i = 1; i < resources.length; i++) {
+    const resource = resources[i] || null;
+    mergedResources = mergedResources.merge(resource);
+  }
+
+  return mergedResources;
+}

--- a/test/merge-resources.test.ts
+++ b/test/merge-resources.test.ts
@@ -20,7 +20,7 @@ describe('mergeResources', () => {
     });
   });
 
-  test('handles undefined values', () => {
+  test('ignores undefined values', () => {
     const resources = [
       undefined,
       new Resource({ hnyId: '12345' }),
@@ -39,7 +39,7 @@ describe('mergeResources', () => {
     });
   });
 
-  test('handles null values', () => {
+  test('ignores null values', () => {
     const resources = [
       new Resource({ hnyId: '12345' }),
       null,
@@ -59,7 +59,7 @@ describe('mergeResources', () => {
     });
   });
 
-  test('handles empty array', () => {
+  test('returns an empty resource when passed an empty array', () => {
     const result = mergeResources([]);
     expect(result).toBeInstanceOf(Resource);
     expect(result.attributes).toEqual({});

--- a/test/merge-resources.test.ts
+++ b/test/merge-resources.test.ts
@@ -1,0 +1,67 @@
+import { Resource } from '@opentelemetry/resources';
+import { mergeResources } from '../src/merge-resources';
+
+describe('mergeResources', () => {
+  test('merges all resources', () => {
+    const resources = [
+      new Resource({ hnyId: '12345' }),
+      new Resource({ customAttribute: 'unique', customized: true, id: 5886 }),
+    ];
+
+    const result = mergeResources(resources);
+    expect(result).toBeInstanceOf(Resource);
+
+    const attributes = result.attributes;
+    expect(attributes).toEqual({
+      hnyId: '12345',
+      customAttribute: 'unique',
+      customized: true,
+      id: 5886,
+    });
+  });
+
+  test('handles undefined values', () => {
+    const resources = [
+      undefined,
+      new Resource({ hnyId: '12345' }),
+      new Resource({ customAttribute: 'unique', customized: true, id: 5886 }),
+    ];
+
+    const result = mergeResources(resources);
+    expect(result).toBeInstanceOf(Resource);
+
+    const attributes = result.attributes;
+    expect(attributes).toEqual({
+      hnyId: '12345',
+      customAttribute: 'unique',
+      customized: true,
+      id: 5886,
+    });
+  });
+
+  test('handles null values', () => {
+    const resources = [
+      new Resource({ hnyId: '12345' }),
+      null,
+      new Resource({ customAttribute: 'unique', customized: true, id: 5886 }),
+      null,
+    ];
+
+    const result = mergeResources(resources);
+    expect(result).toBeInstanceOf(Resource);
+
+    const attributes = result.attributes;
+    expect(attributes).toEqual({
+      hnyId: '12345',
+      customAttribute: 'unique',
+      customized: true,
+      id: 5886,
+    });
+  });
+
+  test('handles empty array', () => {
+    const result = mergeResources([]);
+    expect(result).toBeInstanceOf(Resource);
+    expect(result.attributes).toEqual({});
+  });
+});


### PR DESCRIPTION
## Short description of the changes
Adds utility function to support merging an array of resources into a singular resource

## Why?
For ergonomics & to support creating small, single-purpose resource-builders: see #30

Moves the overhead of merging resources out of the individual configuration builders & into one centralized location: pass in an array of resources, get a singular resource w/ all the available attributes back
