### PR TITLE
feat: add debug mode

### DIFF
--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -20,6 +20,19 @@ describe('Smoke Tests', () => {
     );
   });
 
+  it('logs honeycomb config with debug enabled', () => {
+    cy.visit('http://localhost:3000', {
+      onBeforeLoad(win) {
+        cy.stub(win.console, 'debug').as('consoleDebug');
+      },
+    });
+
+    cy.get('@consoleDebug').should(
+      'be.calledWithMatch',
+      'Honeycomb Web SDK Debug Mode Enabled',
+    );
+  });
+
   it('logs document load traces', () => {
     cy.visit('http://localhost:3000', {
       onBeforeLoad(win) {

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -36,17 +36,17 @@ describe('Smoke Tests', () => {
   it('logs document load traces', () => {
     cy.visit('http://localhost:3000', {
       onBeforeLoad(win) {
-        cy.stub(win.console, 'debug').as('consoleDebug');
+        cy.stub(win.console, 'dir').as('consoleDir');
       },
     });
 
-    cy.get('@consoleDebug').should('be.calledWithMatch', {
+    cy.get('@consoleDir').should('be.calledWithMatch', {
       name: 'documentLoad',
     });
-    cy.get('@consoleDebug').should('be.calledWithMatch', {
+    cy.get('@consoleDir').should('be.calledWithMatch', {
       name: 'resourceFetch',
     });
-    cy.get('@consoleDebug').should('be.calledWithMatch', {
+    cy.get('@consoleDir').should('be.calledWithMatch', {
       name: 'documentFetch',
     });
   });

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -36,17 +36,17 @@ describe('Smoke Tests', () => {
   it('logs document load traces', () => {
     cy.visit('http://localhost:3000', {
       onBeforeLoad(win) {
-        cy.stub(win.console, 'dir').as('consoleDir');
+        cy.stub(win.console, 'debug').as('consoleDebug');
       },
     });
 
-    cy.get('@consoleDir').should('be.calledWithMatch', {
+    cy.get('@consoleDebug').should('be.calledWithMatch', {
       name: 'documentLoad',
     });
-    cy.get('@consoleDir').should('be.calledWithMatch', {
+    cy.get('@consoleDebug').should('be.calledWithMatch', {
       name: 'resourceFetch',
     });
-    cy.get('@consoleDir').should('be.calledWithMatch', {
+    cy.get('@consoleDebug').should('be.calledWithMatch', {
       name: 'documentFetch',
     });
   });

--- a/examples/hello-world-web/index.js
+++ b/examples/hello-world-web/index.js
@@ -1,15 +1,12 @@
 import { HoneycombWebSDK } from '@honeycombio/opentelemetry-web';
-import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 
 const main = () => {
-  // Set OTel to log in Debug mode
-  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
-
   // Initialize base OTel WebSDK
   const sdk = new HoneycombWebSDK({
     apiKey: 'api-key-goes-here',
     serviceName: 'web-distro',
+    debug: true,
     instrumentations: [getWebAutoInstrumentations()], // add auto-instrumentation
   });
   sdk.start();

--- a/src/honeycomb-debug.ts
+++ b/src/honeycomb-debug.ts
@@ -1,6 +1,12 @@
 import { HoneycombOptions } from './types';
 import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
-import { defaultOptions, getTracesApiKey, getTracesEndpoint } from './util';
+import {
+  defaultOptions,
+  getTracesApiKey,
+  getTracesEndpoint,
+  MISSING_API_KEY_ERROR,
+  MISSING_SERVICE_NAME_ERROR,
+} from './util';
 
 /**
  * Configures the Honeycomb Web SDK to log debug information to the console.
@@ -12,14 +18,31 @@ import { defaultOptions, getTracesApiKey, getTracesEndpoint } from './util';
 export function configureDebug(options?: HoneycombOptions): void {
   if (options?.debug) {
     diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
-    diag.debug('Honeycomb Web SDK Debug Mode Enabled');
+    diag.debug('🐝 Honeycomb Web SDK Debug Mode Enabled 🐝');
     const currentOptions = { ...defaultOptions, ...options };
 
-    currentOptions.apiKey = getTracesApiKey(currentOptions);
-    currentOptions.tracesApiKey = getTracesApiKey(currentOptions);
-    currentOptions.endpoint = getTracesEndpoint(options);
+    // tracesApiKey and tracesEndpoint need to be computed from apiKey and endpoint
+    currentOptions.tracesApiKey = getTracesApiKey(options) || '';
     currentOptions.tracesEndpoint = getTracesEndpoint(options);
 
-    diag.debug(JSON.stringify(currentOptions, null, 2));
+    if (currentOptions.tracesApiKey === '') {
+      diag.debug(MISSING_API_KEY_ERROR);
+    } else {
+      diag.debug(
+        `@honeycombio/opentelemetry-web: API Key configured for traces: '${currentOptions.tracesApiKey}'`,
+      );
+    }
+
+    diag.debug(
+      `@honeycombio/opentelemetry-web: Endpoint configured for traces: '${currentOptions.tracesEndpoint}'`,
+    );
+
+    if (currentOptions.serviceName == defaultOptions.serviceName) {
+      diag.debug(MISSING_SERVICE_NAME_ERROR);
+    } else {
+      diag.debug(
+        `@honeycombio/opentelemetry-web: Service Name configured for traces: '${currentOptions.serviceName}'`,
+      );
+    }
   }
 }

--- a/src/honeycomb-debug.ts
+++ b/src/honeycomb-debug.ts
@@ -1,6 +1,6 @@
 import { HoneycombOptions } from './types';
 import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
-import { getTracesApiKey, getTracesEndpoint } from './util';
+import { defaultOptions, getTracesApiKey, getTracesEndpoint } from './util';
 
 /**
  * Configures the Honeycomb Web SDK to log debug information to the console.
@@ -9,31 +9,17 @@ import { getTracesApiKey, getTracesEndpoint } from './util';
  *
  * @param options the provided Honeycomb options
  */
-
 export function configureDebug(options?: HoneycombOptions): void {
-  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
-  diag.debug('Honeycomb Web SDK Debug Mode Enabled');
   if (options?.debug) {
-    options.apiKey
-      ? options.apiKey
-      : (options.apiKey = getTracesApiKey(options));
+    diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+    diag.debug('Honeycomb Web SDK Debug Mode Enabled');
+    const currentOptions = { ...defaultOptions, ...options };
 
-    if (options.apiKey == undefined) {
-      options.apiKey = 'MISSING';
-    }
+    currentOptions.apiKey = getTracesApiKey(currentOptions);
+    currentOptions.tracesApiKey = getTracesApiKey(currentOptions);
+    currentOptions.endpoint = getTracesEndpoint(options);
+    currentOptions.tracesEndpoint = getTracesEndpoint(options);
 
-    options.serviceName
-      ? options.serviceName
-      : (options.serviceName = 'MISSING');
-
-    options.endpoint
-      ? options.endpoint
-      : (options.endpoint = getTracesEndpoint(options));
-
-    options.tracesEndpoint
-      ? options.tracesEndpoint
-      : (options.tracesEndpoint = getTracesEndpoint(options));
-
-    diag.debug(JSON.stringify(options, null, 2));
+    diag.debug(JSON.stringify(currentOptions, null, 2));
   }
 }

--- a/src/honeycomb-debug.ts
+++ b/src/honeycomb-debug.ts
@@ -1,0 +1,39 @@
+import { HoneycombOptions } from './types';
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+import { getTracesApiKey, getTracesEndpoint } from './util';
+
+/**
+ * Configures the Honeycomb Web SDK to log debug information to the console.
+ * Enables the DiagConsoleLogger and sets the log level to DEBUG.
+ * Logs the provided Honeycomb options to the console, as well as defaults.
+ *
+ * @param options the provided Honeycomb options
+ */
+
+export function configureDebug(options?: HoneycombOptions): void {
+  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+  diag.debug('Honeycomb Web SDK Debug Mode Enabled');
+  if (options?.debug) {
+    options.apiKey
+      ? options.apiKey
+      : (options.apiKey = getTracesApiKey(options));
+
+    if (options.apiKey == undefined) {
+      options.apiKey = 'MISSING';
+    }
+
+    options.serviceName
+      ? options.serviceName
+      : (options.serviceName = 'MISSING');
+
+    options.endpoint
+      ? options.endpoint
+      : (options.endpoint = getTracesEndpoint(options));
+
+    options.tracesEndpoint
+      ? options.tracesEndpoint
+      : (options.tracesEndpoint = getTracesEndpoint(options));
+
+    diag.debug(JSON.stringify(options, null, 2));
+  }
+}

--- a/src/honeycomb-debug.ts
+++ b/src/honeycomb-debug.ts
@@ -16,33 +16,54 @@ import {
  * @param options the provided Honeycomb options
  */
 export function configureDebug(options?: HoneycombOptions): void {
-  if (options?.debug) {
-    diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
-    diag.debug('🐝 Honeycomb Web SDK Debug Mode Enabled 🐝');
-    const currentOptions = { ...defaultOptions, ...options };
-
-    // tracesApiKey and tracesEndpoint need to be computed from apiKey and endpoint
-    currentOptions.tracesApiKey = getTracesApiKey(options) || '';
-    currentOptions.tracesEndpoint = getTracesEndpoint(options);
-
-    if (currentOptions.tracesApiKey === '') {
-      diag.debug(MISSING_API_KEY_ERROR);
-    } else {
-      diag.debug(
-        `@honeycombio/opentelemetry-web: API Key configured for traces: '${currentOptions.tracesApiKey}'`,
-      );
-    }
-
-    diag.debug(
-      `@honeycombio/opentelemetry-web: Endpoint configured for traces: '${currentOptions.tracesEndpoint}'`,
-    );
-
-    if (currentOptions.serviceName == defaultOptions.serviceName) {
-      diag.debug(MISSING_SERVICE_NAME_ERROR);
-    } else {
-      diag.debug(
-        `@honeycombio/opentelemetry-web: Service Name configured for traces: '${currentOptions.serviceName}'`,
-      );
-    }
+  if (!options?.debug) {
+    return;
   }
+  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+  diag.debug('🐝 Honeycomb Web SDK Debug Mode Enabled 🐝');
+
+  // traces endpoint must be computed from provided options
+  const tracesEndpoint = getTracesEndpoint(options);
+  const currentOptions = {
+    ...defaultOptions,
+    ...options,
+    tracesEndpoint,
+  };
+
+  debugTracesApiKey(currentOptions);
+  debugServiceName(currentOptions);
+  debugTracesEndpoint(currentOptions);
+}
+
+function debugTracesApiKey(options: HoneycombOptions): void {
+  const tracesApiKey = getTracesApiKey(options) || '';
+  if (!tracesApiKey) {
+    diag.debug(MISSING_API_KEY_ERROR);
+    return;
+  }
+  diag.debug(
+    `@honeycombio/opentelemetry-web: API Key configured for traces: '${tracesApiKey}'`,
+  );
+}
+
+function debugServiceName(options: HoneycombOptions): void {
+  const serviceName = options.serviceName || defaultOptions.serviceName;
+  if (serviceName === defaultOptions.serviceName) {
+    diag.debug(MISSING_SERVICE_NAME_ERROR);
+    return;
+  }
+  diag.debug(
+    `@honeycombio/opentelemetry-web: Service Name configured for traces: '${serviceName}'`,
+  );
+}
+
+function debugTracesEndpoint(options: HoneycombOptions): void {
+  const tracesEndpoint = getTracesEndpoint(options);
+  if (!tracesEndpoint) {
+    diag.debug('No endpoint configured for traces');
+    return;
+  }
+  diag.debug(
+    `@honeycombio/opentelemetry-web: Endpoint configured for traces: '${tracesEndpoint}'`,
+  );
 }

--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -2,6 +2,7 @@ import { WebSDK } from './base-otel-sdk';
 import { HoneycombOptions } from './types';
 import { configureHoneycombHttpJsonTraceExporter } from './http-json-trace-exporter';
 import { configureHoneycombResource } from './honeycomb-resource';
+import { configureDebug } from './honeycomb-debug';
 
 export class HoneycombWebSDK extends WebSDK {
   constructor(options?: HoneycombOptions) {
@@ -11,5 +12,9 @@ export class HoneycombWebSDK extends WebSDK {
 
       ...options,
     });
+
+    if (options?.debug) {
+      configureDebug(options);
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,7 +77,9 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
    */
   sampleRate?: number;
 
-  /** The debug flag enables additional logging that us useful when debugging your application. Do not use in production. */
+  /** The debug flag enables additional logging that us useful when debugging your application. Do not use in production.
+   * Defaults to 'false'.
+   */
   debug?: boolean;
 
   /** The local visualizations flag enables logging Honeycomb URLs for completed traces. Do not use in production. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,20 +74,25 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
 
   /** The sample rate used to determine whether a trace is exported. Defaults to 1 (send everything).
    * If you want to send a random fraction of traces, make this a whole number greater than 1. Only 1 in `sampleRate` traces will be sent.
+   * TODO: Not yet implemented
    */
-  sampleRate?: number;
+  // sampleRate?: number;
 
   /** The debug flag enables additional logging that us useful when debugging your application. Do not use in production.
    * Defaults to 'false'.
    */
   debug?: boolean;
 
-  /** The local visualizations flag enables logging Honeycomb URLs for completed traces. Do not use in production. */
-  localVisualizations?: boolean;
+  /** The local visualizations flag enables logging Honeycomb URLs for completed traces. Do not use in production.
+   * Defaults to 'false'.
+   * TODO: Not yet implemented
+   */
+  // localVisualizations?: boolean;
 
   /** Skip options validation warnings (eg no API key configured). This is useful when the SDK is being
-   * used in conjuction with an OpenTelemetry Collector (which will handle the API key and dataset configuration).
+   * used in conjunction with an OpenTelemetry Collector (which will handle the API key and dataset configuration).
    * Defaults to 'false'.
+   * TODO: Not yet implemented
    */
-  skipOptionsValidation?: boolean;
+  // skipOptionsValidation?: boolean;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,6 +22,9 @@ export const defaultOptions: HoneycombOptions = {
   // skipOptionsValidation: false,
 };
 
+export const MISSING_API_KEY_ERROR = `❌ @honeycombio/opentelemetry-web: Missing API Key. Set \`apiKey\` in HoneycombOptions. Telemetry will not be exported.`;
+export const MISSING_SERVICE_NAME_ERROR = `❌ @honeycombio/opentelemetry-web: Missing Service Name. Set \`serviceName\` in HoneycombOptions. Defaulting to '${defaultOptions.serviceName}'`;
+
 /**
  * Determines whether the passed in apikey is classic (32 chars) or not.
  *

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,6 +3,24 @@ import { HoneycombOptions } from './types';
 // Constants
 export const DEFAULT_API_ENDPOINT = 'https://api.honeycomb.io';
 export const TRACES_PATH = 'v1/traces';
+export const DEFAULT_TRACES_ENDPOINT = `${DEFAULT_API_ENDPOINT}/${TRACES_PATH}`;
+export const DEFAULT_SERVICE_NAME = 'unknown_service';
+
+/**
+ * Default options for the Honeycomb Web SDK.
+ */
+export const defaultOptions: HoneycombOptions = {
+  apiKey: '',
+  tracesApiKey: '',
+  endpoint: DEFAULT_TRACES_ENDPOINT,
+  tracesEndpoint: DEFAULT_TRACES_ENDPOINT,
+  serviceName: DEFAULT_SERVICE_NAME,
+  debug: false,
+  // TODO: Not yet implemented
+  // sampleRate: 1,
+  // localVisualizations: false,
+  // skipOptionsValidation: false,
+};
 
 /**
  * Determines whether the passed in apikey is classic (32 chars) or not.
@@ -40,7 +58,7 @@ export const getTracesEndpoint = (options?: HoneycombOptions) => {
     return maybeAppendTracesPath(options.endpoint);
   }
 
-  return `${DEFAULT_API_ENDPOINT}/${TRACES_PATH}`;
+  return DEFAULT_TRACES_ENDPOINT;
 };
 
 export const getTracesApiKey = (options?: HoneycombOptions) => {

--- a/test/honeycomb-debug.test.ts
+++ b/test/honeycomb-debug.test.ts
@@ -1,5 +1,10 @@
 import { HoneycombWebSDK } from '../src/honeycomb-otel-sdk';
-import { defaultOptions } from '../src/util';
+import {
+  defaultOptions,
+  MISSING_API_KEY_ERROR,
+  MISSING_SERVICE_NAME_ERROR,
+  TRACES_PATH,
+} from '../src/util';
 
 const consoleSpy = jest
   .spyOn(console, 'debug')
@@ -14,49 +19,42 @@ afterAll(() => {
 });
 
 describe('when debug is set to true', () => {
-  it('should log the debug information with defaults to the console', () => {
-    new HoneycombWebSDK({
-      debug: true,
-    });
-    const expectedConfig = JSON.stringify(
-      {
-        apiKey: defaultOptions.apiKey,
-        tracesApiKey: defaultOptions.tracesApiKey,
-        endpoint: defaultOptions.tracesEndpoint,
-        tracesEndpoint: defaultOptions.tracesEndpoint,
-        serviceName: defaultOptions.serviceName,
+  describe('when options are missing', () => {
+    it('should log defaults and errors to the console', () => {
+      new HoneycombWebSDK({
         debug: true,
-      },
-      null,
-      2,
-    );
-    expect(consoleSpy.mock.calls[1][0]).toContain(
-      'Honeycomb Web SDK Debug Mode Enabled',
-    );
-    expect(consoleSpy.mock.calls[2][0]).toContain(expectedConfig);
+      });
+      expect(consoleSpy.mock.calls[1][0]).toContain(
+        'Honeycomb Web SDK Debug Mode Enabled',
+      );
+      expect(consoleSpy.mock.calls[2][0]).toContain(MISSING_API_KEY_ERROR);
+      expect(consoleSpy.mock.calls[3][0]).toContain(
+        `@honeycombio/opentelemetry-web: Endpoint configured for traces: '${defaultOptions.tracesEndpoint}'`,
+      );
+      expect(consoleSpy.mock.calls[4][0]).toContain(MISSING_SERVICE_NAME_ERROR);
+    });
   });
-  it('should log the provided options configuration to the console', () => {
-    new HoneycombWebSDK({
-      debug: true,
-      endpoint: 'http://shenanigans:1234',
-      apiKey: 'my-key',
-      serviceName: 'my-service',
-    });
-    const expectedConfig = JSON.stringify(
-      {
-        apiKey: 'my-key',
-        tracesApiKey: 'my-key',
-        endpoint: 'http://shenanigans:1234/v1/traces',
-        tracesEndpoint: 'http://shenanigans:1234/v1/traces',
-        serviceName: 'my-service',
+  describe('when options are provided', () => {
+    it('should log the configured options to the console', () => {
+      const testConfig = {
         debug: true,
-      },
-      null,
-      2,
-    );
-    expect(consoleSpy.mock.calls[1][0]).toContain(
-      'Honeycomb Web SDK Debug Mode Enabled',
-    );
-    expect(consoleSpy.mock.calls[2][0]).toContain(expectedConfig);
+        endpoint: 'http://shenanigans:1234',
+        apiKey: 'my-key',
+        serviceName: 'my-service',
+      };
+      new HoneycombWebSDK(testConfig);
+      expect(consoleSpy.mock.calls[1][0]).toContain(
+        'Honeycomb Web SDK Debug Mode Enabled',
+      );
+      expect(consoleSpy.mock.calls[2][0]).toContain(
+        `@honeycombio/opentelemetry-web: API Key configured for traces: '${testConfig.apiKey}'`,
+      );
+      expect(consoleSpy.mock.calls[3][0]).toContain(
+        `@honeycombio/opentelemetry-web: Endpoint configured for traces: '${testConfig.endpoint}/${TRACES_PATH}'`,
+      );
+      expect(consoleSpy.mock.calls[4][0]).toContain(
+        `@honeycombio/opentelemetry-web: Service Name configured for traces: '${testConfig.serviceName}'`,
+      );
+    });
   });
 });

--- a/test/honeycomb-debug.test.ts
+++ b/test/honeycomb-debug.test.ts
@@ -1,4 +1,5 @@
 import { HoneycombWebSDK } from '../src/honeycomb-otel-sdk';
+import { defaultOptions } from '../src/util';
 
 const consoleSpy = jest
   .spyOn(console, 'debug')
@@ -13,17 +14,18 @@ afterAll(() => {
 });
 
 describe('when debug is set to true', () => {
-  it('should log the debug information to the console', () => {
+  it('should log the debug information with defaults to the console', () => {
     new HoneycombWebSDK({
       debug: true,
     });
     const expectedConfig = JSON.stringify(
       {
+        apiKey: defaultOptions.apiKey,
+        tracesApiKey: defaultOptions.tracesApiKey,
+        endpoint: defaultOptions.tracesEndpoint,
+        tracesEndpoint: defaultOptions.tracesEndpoint,
+        serviceName: defaultOptions.serviceName,
         debug: true,
-        apiKey: 'MISSING',
-        serviceName: 'MISSING',
-        endpoint: 'https://api.honeycomb.io/v1/traces',
-        tracesEndpoint: 'https://api.honeycomb.io/v1/traces',
       },
       null,
       2,
@@ -42,11 +44,12 @@ describe('when debug is set to true', () => {
     });
     const expectedConfig = JSON.stringify(
       {
-        debug: true,
-        endpoint: 'http://shenanigans:1234',
         apiKey: 'my-key',
-        serviceName: 'my-service',
+        tracesApiKey: 'my-key',
+        endpoint: 'http://shenanigans:1234/v1/traces',
         tracesEndpoint: 'http://shenanigans:1234/v1/traces',
+        serviceName: 'my-service',
+        debug: true,
       },
       null,
       2,

--- a/test/honeycomb-debug.test.ts
+++ b/test/honeycomb-debug.test.ts
@@ -1,4 +1,4 @@
-import { configureDebug } from '../src/honeycomb-debug';
+import { HoneycombWebSDK } from '../dist/src';
 
 const consoleSpy = jest
   .spyOn(console, 'debug')
@@ -14,42 +14,46 @@ afterAll(() => {
 
 describe('when debug is set to true', () => {
   it('should log the debug information to the console', () => {
-    configureDebug({
+    new HoneycombWebSDK({
       debug: true,
     });
-    const expectedConfig = {
-      debug: true,
-      apiKey: 'MISSING',
-      serviceName: 'MISSING',
-      endpoint: 'https://api.honeycomb.io',
-      tracesEndpoint: 'https://api.honeycomb.io/v1/traces',
-    };
-    expect(consoleSpy).toHaveBeenCalledWith(
+    const expectedConfig = JSON.stringify(
+      {
+        debug: true,
+        apiKey: 'MISSING',
+        serviceName: 'MISSING',
+        endpoint: 'https://api.honeycomb.io/v1/traces',
+        tracesEndpoint: 'https://api.honeycomb.io/v1/traces',
+      },
+      null,
+      2,
+    );
+    expect(consoleSpy.mock.calls[1][0]).toContain(
       'Honeycomb Web SDK Debug Mode Enabled',
     );
-    expect(consoleSpy).toHaveBeenCalledWith(
-      JSON.stringify(expectedConfig, null, 2),
-    );
+    expect(consoleSpy.mock.calls[2][0]).toContain(expectedConfig);
   });
   it('should log the provided options configuration to the console', () => {
-    configureDebug({
+    new HoneycombWebSDK({
       debug: true,
       endpoint: 'http://shenanigans:1234',
       apiKey: 'my-key',
       serviceName: 'my-service',
     });
-    const expectedConfig = {
-      debug: true,
-      apiKey: 'my-key',
-      serviceName: 'my-service',
-      endpoint: 'http://shenanigans:1234',
-      tracesEndpoint: 'http://shenanigans:1234/v1/traces',
-    };
-    expect(consoleSpy).toHaveBeenCalledWith(
+    const expectedConfig = JSON.stringify(
+      {
+        debug: true,
+        endpoint: 'http://shenanigans:1234',
+        apiKey: 'my-key',
+        serviceName: 'my-service',
+        tracesEndpoint: 'http://shenanigans:1234/v1/traces',
+      },
+      null,
+      2,
+    );
+    expect(consoleSpy.mock.calls[1][0]).toContain(
       'Honeycomb Web SDK Debug Mode Enabled',
     );
-    expect(consoleSpy).toHaveBeenCalledWith(
-      JSON.stringify(expectedConfig, null, 2),
-    );
+    expect(consoleSpy.mock.calls[2][0]).toContain(expectedConfig);
   });
 });

--- a/test/honeycomb-debug.test.ts
+++ b/test/honeycomb-debug.test.ts
@@ -1,0 +1,55 @@
+import { configureDebug } from '../src/honeycomb-debug';
+
+const consoleSpy = jest
+  .spyOn(console, 'debug')
+  .mockImplementation(() => undefined);
+
+afterEach(() => {
+  consoleSpy.mockClear();
+});
+
+afterAll(() => {
+  consoleSpy.mockRestore();
+});
+
+describe('when debug is set to true', () => {
+  it('should log the debug information to the console', () => {
+    configureDebug({
+      debug: true,
+    });
+    const expectedConfig = {
+      debug: true,
+      apiKey: 'MISSING',
+      serviceName: 'MISSING',
+      endpoint: 'https://api.honeycomb.io',
+      tracesEndpoint: 'https://api.honeycomb.io/v1/traces',
+    };
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Honeycomb Web SDK Debug Mode Enabled',
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      JSON.stringify(expectedConfig, null, 2),
+    );
+  });
+  it('should log the provided options configuration to the console', () => {
+    configureDebug({
+      debug: true,
+      endpoint: 'http://shenanigans:1234',
+      apiKey: 'my-key',
+      serviceName: 'my-service',
+    });
+    const expectedConfig = {
+      debug: true,
+      apiKey: 'my-key',
+      serviceName: 'my-service',
+      endpoint: 'http://shenanigans:1234',
+      tracesEndpoint: 'http://shenanigans:1234/v1/traces',
+    };
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Honeycomb Web SDK Debug Mode Enabled',
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      JSON.stringify(expectedConfig, null, 2),
+    );
+  });
+});

--- a/test/honeycomb-debug.test.ts
+++ b/test/honeycomb-debug.test.ts
@@ -1,4 +1,4 @@
-import { HoneycombWebSDK } from '../dist/src';
+import { HoneycombWebSDK } from '../src/honeycomb-otel-sdk';
 
 const consoleSpy = jest
   .spyOn(console, 'debug')

--- a/test/honeycomb-debug.test.ts
+++ b/test/honeycomb-debug.test.ts
@@ -28,10 +28,10 @@ describe('when debug is set to true', () => {
         'Honeycomb Web SDK Debug Mode Enabled',
       );
       expect(consoleSpy.mock.calls[2][0]).toContain(MISSING_API_KEY_ERROR);
-      expect(consoleSpy.mock.calls[3][0]).toContain(
+      expect(consoleSpy.mock.calls[3][0]).toContain(MISSING_SERVICE_NAME_ERROR);
+      expect(consoleSpy.mock.calls[4][0]).toContain(
         `@honeycombio/opentelemetry-web: Endpoint configured for traces: '${defaultOptions.tracesEndpoint}'`,
       );
-      expect(consoleSpy.mock.calls[4][0]).toContain(MISSING_SERVICE_NAME_ERROR);
     });
   });
   describe('when options are provided', () => {
@@ -50,10 +50,10 @@ describe('when debug is set to true', () => {
         `@honeycombio/opentelemetry-web: API Key configured for traces: '${testConfig.apiKey}'`,
       );
       expect(consoleSpy.mock.calls[3][0]).toContain(
-        `@honeycombio/opentelemetry-web: Endpoint configured for traces: '${testConfig.endpoint}/${TRACES_PATH}'`,
+        `@honeycombio/opentelemetry-web: Service Name configured for traces: '${testConfig.serviceName}'`,
       );
       expect(consoleSpy.mock.calls[4][0]).toContain(
-        `@honeycombio/opentelemetry-web: Service Name configured for traces: '${testConfig.serviceName}'`,
+        `@honeycombio/opentelemetry-web: Endpoint configured for traces: '${testConfig.endpoint}/${TRACES_PATH}'`,
       );
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #14 

## Short description of the changes

- add configureDebug function. When debug: true is set, configureDebug creates a `DiagConsoleLogger` with Debug level and also prints HoneycombOptions to console.

## How to verify that this has the expected result

Set `debug: true` in SDK config and see both the output expected from the previously enabled DiagConsoleLogger, as well as configured options for the Honeycomb SDK.

for configured options of key, serviceName, endpoint (without path):
![debug-for-configured-options](https://github.com/honeycombio/honeycomb-opentelemetry-web/assets/29520003/3b2d7080-a213-4008-84d0-1acc70fe6d29)

for missing options (is this excessive?):
![debug-for-missing-options](https://github.com/honeycombio/honeycomb-opentelemetry-web/assets/29520003/379f3355-d72d-4e39-9fa2-90f1853fdbdd)




~Note I'm not sure why the smoke tests are failing (local) now 🤔  I tried updating but may need an extra set of eyes on that, maybe as a follow-up? Confirmed the instrumentation is showing in the console from manually running the app.~
**Update**: It looks like it doesn't work because the DiagConsoleLogger only logs output if it can successfully export - the app defaults to sending to Honeycomb without a valid key, so nothing gets logged to the console. By adding a ConsoleSpanExporter, I can confirm the smoke tests pass. I'll consider that for updating the smoke tests further.
