### PR TITLE
maint: add github project workflow

### DIFF
--- a/.github/workflows/add-to-project-v2.yml
+++ b/.github/workflows/add-to-project-v2.yml
@@ -1,0 +1,15 @@
+name: Add to project
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    name: Add issues and PRs to project
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/honeycombio/projects/30
+          github-token: ${{ secrets.GHPROJECTS_TOKEN }}


### PR DESCRIPTION
## Which problem is this PR solving?

- tracking repo on a project board

## Short description of the changes

- adds the github project workflow to automatically add issues and prs from this repo to the project board

## How to verify that this has the expected result

new issues and PRs should show up on our project board