### PR TITLE
maint: setup publish steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,20 @@ filters_always: &filters_always
     tags:
       only: /.*/
 
+filters_publish: &filters_publish
+  filters:
+    tags:
+      only: /^v[0-9].*/
+    branches:
+      ignore: /.*/
+
 executors:
   node:
     docker:
       - image: cimg/node:16.16
+  github:
+    docker:
+      - image: cibuilds/github:0.13.0
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,23 @@ jobs:
       - store_artifacts:
           path: ./reports/
 
+  publish_github:
+    executor: github
+    steps:
+      - run:
+          name: "GHR Draft"
+          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG}
+
+  publish_npm:
+    executor: node
+    steps:
+      - checkout
+      - run:
+          name: store npm auth token
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --access public
 
 workflows:
   build:
@@ -68,3 +85,13 @@ workflows:
           <<: *filters_always
           requires:
             - test
+      - publish_github:
+          <<: *filters_publish
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build
+      - publish_npm:
+          <<: *filters_publish
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # Honeycomb OpenTelemetry Web
 
-<!-- OSS metadata badge - rename repo link and set status in OSSMETADATA -->
-<!-- [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/{repo-name})](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md) -->
+[![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/honeycomb-opentelemetry-web)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
+[![CircleCI](https://circleci.com/gh/honeycombio/honeycomb-opentelemetry-web.svg?style=shield)](https://circleci.com/gh/honeycombio/honeycomb-opentelemetry-web)
+[![npm](https://img.shields.io/npm/v/@honeycombio/opentelemetry-web)](https://www.npmjs.com/package/@honeycombio/opentelemetry-web)
 
 Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) in the browser.
+<!-- TODO: happy badges of the OTel versions we are using -->
+**STATUS: this library is ALPHA.**
 
-// TODO: happy badges of the OTel versions we are using
+Latest release:
+
+* built with OpenTelemetry JS [Stable v1.19.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.19.0), [Experimental v0.46.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.46.0), [API v1.7.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/api%2Fv1.7.0)
+* compatible with OpenTelemetry Auto-Instrumentations for Web [~0.34.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-node-v0.34.0)
 
 This package sets up OpenTelemetry for tracing, using our recommended practices, including:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,13 +1,21 @@
 # Releasing
 
-// TODO: the doesn't happen yet
+- Use `npm version --no-git-tag-version` to update the version number using `major`, `minor`, `patch`, or the prerelease variants `premajor`, `preminor`, or `prepatch`.
+  For example, to bump from v1.1.1 to the next patch version:
 
-- `Add steps to prepare release`
-- Update `CHANGELOG.md` with the changes since the last release.
+```shell
+> npm version --no-git-tag-version patch # 1.1.1 -> 1.1.2
+```
+
+- Confirm the version number update appears in `package.json` and `package-lock.json`.
+- Update `CHANGELOG.md` with the changes since the last release. Consider automating with a command such as these two:
+  - `git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline > new-in-this-release.log`
+  - `git log --pretty='%C(green)%d%Creset- %s | %an'`
+- If the upstream OpenTelemetry package versions have changed, update README with new versions and links.
 - Commit changes, push, and open a release preparation pull request for review.
 - Once the pull request is merged, fetch the updated `main` branch.
-- Apply a tag for the new version on the merged commit (e.g. `git tag -a v1.2.3 -m "v1.2.3"`)
-- Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v1.2.3`
-- Copy change log entry for newest version into draft GitHub release created as part of CI publish steps.
-  - Make sure to "generate release notes" in github for full changelog notes and any new contributors
-- Publish the github draft release and this will kick off publishing to GitHub and the NPM registry.
+- Apply a tag for the new version on the merged commit (e.g. `git tag -a v2.3.1 -m "v2.3.1"`)
+- Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v2.3.1`
+- Ensure that there is a draft GitHub release created as part of CI publish steps (this will also publish to NPM).
+- Click "generate release notes" in GitHub for full changelog notes and any new contributors
+- Publish the GitHub draft release - if it is a prerelease (e.g., beta) click the prerelease checkbox.


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #18 

## Short description of the changes

- add steps to circleci config for publishing to github and to npm
- update releasing doc for actual steps needed for releasing package
- update readme with badges and links to compatible OTel versions

Note this doesn't actually _do_ anything yet. To publish we need to make the repo public, and then follow the steps in the releasing doc (specifically pushing up a tag).