### PR TITLE
feat: ✨ Browser attributes span processor (but also so much more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The SDK adds these fields to all telemetry:
 | browser.platform | stable | static | [NavigatorUAData: platform](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/platform) | "Windows" |
 | browser.mobile | stable | static | [NavigatorUAData: mobile](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/mobile) | true |
 | browser.language | stable | static | [Navigator: language](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language) | "fr-FR" |
-| browser.touch_screen_enabled | stable | static |  | true |
+| browser.touch_screen_enabled | stable | static | [Navigator: maxTouchPoints](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/maxTouchPoints) | true |
 | `page.url`      | custom | per-span |   | `https://docs.honeycomb.io/getting-data-in/data-best-practices/#datasets-group-data-together?page=2` |
 | `page.route`     | custom | per-span |   | `/getting-data-in/data-best-practices/`                                                              |
 | `page.search`   | custom | per-span |   | `?page=2`                                                                                            |

--- a/README.md
+++ b/README.md
@@ -103,11 +103,20 @@ The SDK adds these fields to all telemetry:
 | name | status | static? | description | example |
 |------|--------|---------|-------------|---------|
 | user_agent.original | [stable](https://github.com/scheler/opentelemetry-specification/blob/browser-events/specification/resource/semantic_conventions/browser.md) | static | window.user_agent | `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36` |
-| browser.height | planned | per-span | `[window.innerHeight](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerHeight)`, the height of the layout viewport in pixels | 287 |
+| browser.height | planned | per-span | [window.innerHeight](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerHeight), the height of the layout viewport in pixels | 287 |
+| browser.width | planned | per-span | [window.innerWidth](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth), the height of the layout viewport in pixels | 1720 |
 | browser.brands | stable | static | [NavigatorUAData: brands](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/brands) | ["Not_A Brand 8", "Chromium 120", "Google Chrome 120"] |
 | browser.platform | stable | static | [NavigatorUAData: platform](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/platform) | "Windows" |
 | browser.mobile | stable | static | [NavigatorUAData: mobile](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/mobile) | true |
 | browser.language | stable | static | [Navigator: language](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language) | "fr-FR" |
+| browser.touch_screen_enabled | stable | static |  | true |
+| `page.url`      | custom | per-span |   | `https://docs.honeycomb.io/getting-data-in/data-best-practices/#datasets-group-data-together?page=2` |
+| `page.route`     | custom | per-span |   | `/getting-data-in/data-best-practices/`                                                              |
+| `page.search`   | custom | per-span |   | `?page=2`                                                                                            |
+| `page.hash`     | custom | per-span |   | `#datasets-group-data-together`                                                                      |
+| `page.hostname` | custom | per-span |   | `docs.honeycomb.io`   |
+| `screen.width` | custom | static | Total available screen width in pixels.   | `780`   |
+| `screen.height` | custom | static |  Total available screen height in pixels | `1000`   |
 | honeycomb.distro.version | stable | static | package version | "1.2.3" |
 | honeycomb.distro.runtime_version | stable | static | | "browser"
 | `entry_page.url`      | custom | static |   | `https://docs.honeycomb.io/getting-data-in/data-best-practices/#datasets-group-data-together?page=2` |

--- a/src/browser-attributes-resource.ts
+++ b/src/browser-attributes-resource.ts
@@ -1,0 +1,13 @@
+import { Resource } from '@opentelemetry/resources';
+
+export function configureBrowserAttributesResource(): Resource {
+  return new Resource({
+    'user_agent.original': navigator.userAgent,
+    //https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#mobile_tablet_or_desktop
+    'browser.mobile': navigator.userAgent.includes('Mobi'),
+    'browser.touch_screen_enabled': navigator.maxTouchPoints > 0,
+    'browser.language': navigator.language,
+    'screen.width': window.screen.width,
+    'screen.height': window.screen.height,
+  });
+}

--- a/src/browser-attributes-span-processor.ts
+++ b/src/browser-attributes-span-processor.ts
@@ -11,8 +11,8 @@ export class BrowserAttributesSpanProcessor implements SpanProcessor {
 
   onStart(span: Span) {
     span.setAttributes({
-      'browser.width': window.screen.width,
-      'browser.height': window.screen.height,
+      'browser.width': window.innerWidth,
+      'browser.height': window.innerHeight,
       'browser.hash': window.location.hash,
       'browser.url': window.location.href,
       'browser.route': window.location.pathname,

--- a/src/browser-attributes-span-processor.ts
+++ b/src/browser-attributes-span-processor.ts
@@ -10,12 +10,16 @@ export class BrowserAttributesSpanProcessor implements SpanProcessor {
   constructor() {}
 
   onStart(span: Span) {
+    const { href, pathname, search, hash, hostname } = window.location;
+
     span.setAttributes({
       'browser.width': window.innerWidth,
       'browser.height': window.innerHeight,
-      'browser.hash': window.location.hash,
-      'browser.url': window.location.href,
-      'browser.route': window.location.pathname,
+      'page.hash': hash,
+      'page.url': href,
+      'page.route': pathname,
+      'page.hostname': hostname,
+      'page.search': search,
     });
   }
 

--- a/src/browser-attributes-span-processor.ts
+++ b/src/browser-attributes-span-processor.ts
@@ -1,0 +1,26 @@
+import { Span } from '@opentelemetry/api';
+import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
+
+export class BrowserAttributesSpanProcessor implements SpanProcessor {
+  constructor() {}
+
+  onStart(span: Span) {
+    span.setAttributes({
+      'browser.width': window.screen.width,
+      'browser.height': window.screen.height,
+      'browser.hash': window.location.hash,
+      'browser.url': window.location.href,
+      'browser.route': window.location.pathname,
+    });
+  }
+
+  onEnd() {}
+
+  forceFlush() {
+    return Promise.resolve();
+  }
+
+  shutdown() {
+    return Promise.resolve();
+  }
+}

--- a/src/browser-attributes-span-processor.ts
+++ b/src/browser-attributes-span-processor.ts
@@ -1,6 +1,11 @@
 import { Span } from '@opentelemetry/api';
 import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 
+/**
+ * A {@link SpanProcessor} that adds browser specific attributes to each span
+ * that might change over the course of a session.
+ * Static attributes (e.g. User Agent) are added to the Resource.
+ */
 export class BrowserAttributesSpanProcessor implements SpanProcessor {
   constructor() {}
 

--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -15,7 +15,9 @@ export class HoneycombWebSDK extends WebSDK {
         options?.resource,
         configureHoneycombResource(),
       ]),
-      // TODO: leave comment about traceExporter shenanies
+      // Exporter is configured through the span processor because
+      // the base SDK does not allow having both a spanProcessor and a
+      // traceExporter configured at the same time.
       spanProcessor: configureSpanProcessors(options),
     });
 

--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -1,6 +1,5 @@
 import { WebSDK } from './base-otel-sdk';
 import { HoneycombOptions } from './types';
-import { configureHoneycombHttpJsonTraceExporter } from './http-json-trace-exporter';
 import { configureHoneycombResource } from './honeycomb-resource';
 import { configureEntryPageResource } from './entry-page-resource';
 import { mergeResources } from './merge-resources';
@@ -16,7 +15,7 @@ export class HoneycombWebSDK extends WebSDK {
         options?.resource,
         configureHoneycombResource(),
       ]),
-      traceExporter: configureHoneycombHttpJsonTraceExporter(options),
+      // TODO: leave comment about traceExporter shenanies
       spanProcessor: configureSpanProcessors(options),
     });
 

--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -2,6 +2,7 @@ import { WebSDK } from './base-otel-sdk';
 import { HoneycombOptions } from './types';
 import { configureHoneycombResource } from './honeycomb-resource';
 import { configureEntryPageResource } from './entry-page-resource';
+import { configureBrowserAttributesResource } from './browser-attributes-resource';
 import { mergeResources } from './merge-resources';
 import { configureDebug } from './honeycomb-debug';
 import { configureSpanProcessors } from './span-processor-builder';
@@ -12,6 +13,7 @@ export class HoneycombWebSDK extends WebSDK {
       ...options,
       resource: mergeResources([
         configureEntryPageResource(),
+        configureBrowserAttributesResource(),
         options?.resource,
         configureHoneycombResource(),
       ]),

--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -5,7 +5,7 @@ import { configureHoneycombResource } from './honeycomb-resource';
 import { configureEntryPageResource } from './entry-page-resource';
 import { mergeResources } from './merge-resources';
 import { configureDebug } from './honeycomb-debug';
-import { configureSpanProcessor } from './span-processor-builder';
+import { configureSpanProcessors } from './span-processor-builder';
 
 export class HoneycombWebSDK extends WebSDK {
   constructor(options?: HoneycombOptions) {
@@ -17,7 +17,7 @@ export class HoneycombWebSDK extends WebSDK {
         configureHoneycombResource(),
       ]),
       traceExporter: configureHoneycombHttpJsonTraceExporter(options),
-      spanProcessor: configureSpanProcessor(options),
+      spanProcessor: configureSpanProcessors(options),
     });
 
     if (options?.debug) {

--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -5,6 +5,7 @@ import { configureHoneycombResource } from './honeycomb-resource';
 import { configureEntryPageResource } from './entry-page-resource';
 import { mergeResources } from './merge-resources';
 import { configureDebug } from './honeycomb-debug';
+import { configureSpanProcessor } from './span-processor-builder';
 
 export class HoneycombWebSDK extends WebSDK {
   constructor(options?: HoneycombOptions) {
@@ -16,6 +17,7 @@ export class HoneycombWebSDK extends WebSDK {
         configureHoneycombResource(),
       ]),
       traceExporter: configureHoneycombHttpJsonTraceExporter(options),
+      spanProcessor: configureSpanProcessor(options),
     });
 
     if (options?.debug) {

--- a/src/span-processor-builder.ts
+++ b/src/span-processor-builder.ts
@@ -7,40 +7,44 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import { Context } from '@opentelemetry/api';
 
-export const configureSpanProcessor = (options?: HoneycombOptions) => {
-  if (options?.spanProcessor) {
-    return new CombinedSpanProcessor(options.spanProcessor);
-  }
+export const configureSpanProcessors = (options: HoneycombOptions) => {
+  const honeycombSpanProcessor = new CompositeSpanProcessor();
 
-  return new BrowserAttributesSpanProcessor();
+  honeycombSpanProcessor.addProcessor(new BrowserAttributesSpanProcessor());
+
+  if (options.spanProcessor) {
+    honeycombSpanProcessor.addProcessor(options.spanProcessor);
+  }
 };
 
-export class CombinedSpanProcessor implements SpanProcessor {
-  private customSpanProcessor: SpanProcessor;
-  private browserAttrsSpanProcessor: BrowserAttributesSpanProcessor;
+export class CompositeSpanProcessor implements SpanProcessor {
+  private spanProcessors: Array<SpanProcessor> = [];
 
-  constructor(customSpanProcessor: SpanProcessor) {
-    this.customSpanProcessor = customSpanProcessor;
-    this.browserAttrsSpanProcessor = new BrowserAttributesSpanProcessor();
+  public addProcessor(processor: SpanProcessor) {
+    this.spanProcessors.push(processor);
   }
 
   onStart(span: Span, parentContext: Context): void {
-    this.customSpanProcessor.onStart(span, parentContext);
-    this.browserAttrsSpanProcessor.onStart(span);
+    this.spanProcessors.forEach((processor) => {
+      processor.onStart(span, parentContext);
+    });
   }
 
   onEnd(span: ReadableSpan): void {
-    this.customSpanProcessor.onEnd(span);
-    this.browserAttrsSpanProcessor.onEnd();
+    this.spanProcessors.forEach((processor) => {
+      processor.onEnd(span);
+    });
   }
 
-  async forceFlush(): Promise<void> {
-    await this.customSpanProcessor.forceFlush();
-    await this.browserAttrsSpanProcessor.forceFlush();
+  forceFlush(): Promise<void> {
+    return Promise.all(
+      this.spanProcessors.map((processor) => processor.forceFlush()),
+    ).then(() => {});
   }
 
-  async shutdown(): Promise<void> {
-    await this.customSpanProcessor.shutdown();
-    await this.browserAttrsSpanProcessor.shutdown();
+  shutdown(): Promise<void> {
+    return Promise.all(
+      this.spanProcessors.map((processor) => processor.forceFlush()),
+    ).then(() => {});
   }
 }

--- a/src/span-processor-builder.ts
+++ b/src/span-processor-builder.ts
@@ -1,14 +1,26 @@
 import { HoneycombOptions } from './types';
 import { BrowserAttributesSpanProcessor } from './browser-attributes-span-processor';
 import {
+  BatchSpanProcessor,
   ReadableSpan,
   Span,
   SpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { Context } from '@opentelemetry/api';
+import { configureHoneycombHttpJsonTraceExporter } from './http-json-trace-exporter';
+
+// TODO: jsdocs
+// TODO: naming this file
+// TODO: tests
 
 export const configureSpanProcessors = (options?: HoneycombOptions) => {
   const honeycombSpanProcessor = new CompositeSpanProcessor();
+
+  // add exporter
+  // TODO: also leave a comment here
+  honeycombSpanProcessor.addProcessor(
+    new BatchSpanProcessor(configureHoneycombHttpJsonTraceExporter(options)),
+  );
 
   // we always want to add the browser attrs span processor
   honeycombSpanProcessor.addProcessor(new BrowserAttributesSpanProcessor());

--- a/src/span-processor-builder.ts
+++ b/src/span-processor-builder.ts
@@ -1,0 +1,46 @@
+import { HoneycombOptions } from './types';
+import { BrowserAttributesSpanProcessor } from './browser-attributes-span-processor';
+import {
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { Context } from '@opentelemetry/api';
+
+export const configureSpanProcessor = (options?: HoneycombOptions) => {
+  if (options?.spanProcessor) {
+    return new CombinedSpanProcessor(options.spanProcessor);
+  }
+
+  return new BrowserAttributesSpanProcessor();
+};
+
+export class CombinedSpanProcessor implements SpanProcessor {
+  private customSpanProcessor: SpanProcessor;
+  private browserAttrsSpanProcessor: BrowserAttributesSpanProcessor;
+
+  constructor(customSpanProcessor: SpanProcessor) {
+    this.customSpanProcessor = customSpanProcessor;
+    this.browserAttrsSpanProcessor = new BrowserAttributesSpanProcessor();
+  }
+
+  onStart(span: Span, parentContext: Context): void {
+    this.customSpanProcessor.onStart(span, parentContext);
+    this.browserAttrsSpanProcessor.onStart(span);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    this.customSpanProcessor.onEnd(span);
+    this.browserAttrsSpanProcessor.onEnd();
+  }
+
+  async forceFlush(): Promise<void> {
+    await this.customSpanProcessor.forceFlush();
+    await this.browserAttrsSpanProcessor.forceFlush();
+  }
+
+  async shutdown(): Promise<void> {
+    await this.customSpanProcessor.shutdown();
+    await this.browserAttrsSpanProcessor.shutdown();
+  }
+}

--- a/src/span-processor-builder.ts
+++ b/src/span-processor-builder.ts
@@ -40,6 +40,10 @@ export class CompositeSpanProcessor implements SpanProcessor {
     this.spanProcessors.push(processor);
   }
 
+  public getSpanProcessors() {
+    return this.spanProcessors;
+  }
+
   onStart(span: Span, parentContext: Context): void {
     this.spanProcessors.forEach((processor) => {
       processor.onStart(span, parentContext);

--- a/src/span-processor-builder.ts
+++ b/src/span-processor-builder.ts
@@ -9,15 +9,17 @@ import {
 import { Context } from '@opentelemetry/api';
 import { configureHoneycombHttpJsonTraceExporter } from './http-json-trace-exporter';
 
-// TODO: jsdocs
-// TODO: naming this file
-// TODO: tests
-
+/**
+ * Builds and returns Span Processor that combines the BatchSpanProcessor, BrowserSpanProcessor,
+ * and optionally a user provided Span Processor.
+ * @param options The {@link HoneycombOptions}
+ * @returns a {@link CompositeSpanProcessor}
+ */
 export const configureSpanProcessors = (options?: HoneycombOptions) => {
   const honeycombSpanProcessor = new CompositeSpanProcessor();
 
-  // add exporter
-  // TODO: also leave a comment here
+  // We have to configure the exporter here becuase the way the base SDK is setup
+  // does not allow having both a `spanProcessor` and `traceExporter` configured.
   honeycombSpanProcessor.addProcessor(
     new BatchSpanProcessor(configureHoneycombHttpJsonTraceExporter(options)),
   );
@@ -33,6 +35,10 @@ export const configureSpanProcessors = (options?: HoneycombOptions) => {
   return honeycombSpanProcessor;
 };
 
+/**
+ * A {@link SpanProcessor} that combines multiple span processors into a single
+ * span processor that can be passed into the SDKs `spanProcessor` option.
+ */
 export class CompositeSpanProcessor implements SpanProcessor {
   private spanProcessors: Array<SpanProcessor> = [];
 

--- a/src/span-processor-builder.ts
+++ b/src/span-processor-builder.ts
@@ -7,14 +7,18 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import { Context } from '@opentelemetry/api';
 
-export const configureSpanProcessors = (options: HoneycombOptions) => {
+export const configureSpanProcessors = (options?: HoneycombOptions) => {
   const honeycombSpanProcessor = new CompositeSpanProcessor();
 
+  // we always want to add the browser attrs span processor
   honeycombSpanProcessor.addProcessor(new BrowserAttributesSpanProcessor());
 
-  if (options.spanProcessor) {
-    honeycombSpanProcessor.addProcessor(options.spanProcessor);
+  // if there is a user provided span processor, add it to the composite span processor
+  if (options?.spanProcessor) {
+    honeycombSpanProcessor.addProcessor(options?.spanProcessor);
   }
+
+  return honeycombSpanProcessor;
 };
 
 export class CompositeSpanProcessor implements SpanProcessor {

--- a/test/browser-attributes-resource.test.ts
+++ b/test/browser-attributes-resource.test.ts
@@ -1,0 +1,20 @@
+import { configureBrowserAttributesResource } from '../src/browser-attributes-resource';
+import { Resource } from '@opentelemetry/resources';
+
+test('it should return a Resource', () => {
+  const resource = configureBrowserAttributesResource();
+  expect(resource).toBeInstanceOf(Resource);
+});
+
+test('it should have location attributes', () => {
+  const resource = configureBrowserAttributesResource();
+  expect(resource.attributes).toEqual({
+    'browser.language': 'en-US',
+    'browser.mobile': false,
+    'browser.touch_screen_enabled': false,
+    'screen.height': 0,
+    'screen.width': 0,
+    'user_agent.original':
+      'Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3',
+  });
+});

--- a/test/browser-attributes-resource.test.ts
+++ b/test/browser-attributes-resource.test.ts
@@ -14,7 +14,8 @@ test('it should have location attributes', () => {
     'browser.touch_screen_enabled': false,
     'screen.height': 0,
     'screen.width': 0,
-    'user_agent.original':
-      'Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3',
+    // user agent will be different locally and on CI,
+    // we're really only testing to make sure it gets the value
+    'user_agent.original': navigator.userAgent,
   });
 });

--- a/test/browser-attributes-span-processor.test.ts
+++ b/test/browser-attributes-span-processor.test.ts
@@ -40,8 +40,8 @@ describe('BrowserAttributesSpanProcessor', () => {
     browserAttrsSpanProcessor.onStart(span);
 
     expect(span.attributes).toEqual({
-      'browser.width': window.screen.width,
-      'browser.height': window.screen.height,
+      'browser.width': window.innerWidth,
+      'browser.height': window.innerHeight,
       'browser.hash': window.location.hash,
       'browser.url': window.location.href,
       'browser.route': window.location.pathname,

--- a/test/browser-attributes-span-processor.test.ts
+++ b/test/browser-attributes-span-processor.test.ts
@@ -10,6 +10,7 @@ describe('BrowserAttributesSpanProcessor', () => {
 
   beforeEach(() => {
     windowSpy = jest.spyOn(globalThis, 'window', 'get');
+
     span = new Span(
       new BasicTracerProvider().getTracer('browser-attrs-testing'),
       ROOT_CONTEXT,

--- a/test/browser-attributes-span-processor.test.ts
+++ b/test/browser-attributes-span-processor.test.ts
@@ -31,10 +31,8 @@ describe('BrowserAttributesSpanProcessor', () => {
         href: 'https://example.com/some-path#testing',
         pathname: '/some-path',
       },
-      screen: {
-        width: 1440,
-        height: 982,
-      },
+      innerWidth: 1720,
+      innerHeight: 1000,
     }));
 
     browserAttrsSpanProcessor.onStart(span);
@@ -42,9 +40,11 @@ describe('BrowserAttributesSpanProcessor', () => {
     expect(span.attributes).toEqual({
       'browser.width': window.innerWidth,
       'browser.height': window.innerHeight,
-      'browser.hash': window.location.hash,
-      'browser.url': window.location.href,
-      'browser.route': window.location.pathname,
+      'page.hash': window.location.hash,
+      'page.url': window.location.href,
+      'page.route': window.location.pathname,
+      'page.hostname': window.location.hostname,
+      'page.search': window.location.search,
     });
   });
 });

--- a/test/browser-attributes-span-processor.test.ts
+++ b/test/browser-attributes-span-processor.test.ts
@@ -1,0 +1,49 @@
+import { BrowserAttributesSpanProcessor } from '../src/browser-attributes-span-processor';
+import { ROOT_CONTEXT, SpanKind, TraceFlags } from '@opentelemetry/api';
+import { BasicTracerProvider, Span } from '@opentelemetry/sdk-trace-base';
+
+describe('BrowserAttributesSpanProcessor', () => {
+  const browserAttrsSpanProcessor = new BrowserAttributesSpanProcessor();
+
+  let span: Span;
+  let windowSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    windowSpy = jest.spyOn(globalThis, 'window', 'get');
+    span = new Span(
+      new BasicTracerProvider().getTracer('browser-attrs-testing'),
+      ROOT_CONTEXT,
+      'A Very Important Browser Span!',
+      {
+        traceId: '',
+        spanId: '',
+        traceFlags: TraceFlags.SAMPLED,
+      },
+      SpanKind.CLIENT,
+    );
+  });
+
+  test('Span processor adds extra browser attributes', () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        hash: '#testing',
+        href: 'https://example.com/some-path#testing',
+        pathname: '/some-path',
+      },
+      screen: {
+        width: 1440,
+        height: 982,
+      },
+    }));
+
+    browserAttrsSpanProcessor.onStart(span);
+
+    expect(span.attributes).toEqual({
+      'browser.width': window.screen.width,
+      'browser.height': window.screen.height,
+      'browser.hash': window.location.hash,
+      'browser.url': window.location.href,
+      'browser.route': window.location.pathname,
+    });
+  });
+});

--- a/test/browser-attributes-span-processor.test.ts
+++ b/test/browser-attributes-span-processor.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment-options {"url": "http://something-something.com/some-page?search_params=yes&hello=hi#the-hash"}
+ */
+
 import { BrowserAttributesSpanProcessor } from '../src/browser-attributes-span-processor';
 import { ROOT_CONTEXT, SpanKind, TraceFlags } from '@opentelemetry/api';
 import { BasicTracerProvider, Span } from '@opentelemetry/sdk-trace-base';
@@ -6,11 +10,8 @@ describe('BrowserAttributesSpanProcessor', () => {
   const browserAttrsSpanProcessor = new BrowserAttributesSpanProcessor();
 
   let span: Span;
-  let windowSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    windowSpy = jest.spyOn(globalThis, 'window', 'get');
-
     span = new Span(
       new BasicTracerProvider().getTracer('browser-attrs-testing'),
       ROOT_CONTEXT,
@@ -25,26 +26,17 @@ describe('BrowserAttributesSpanProcessor', () => {
   });
 
   test('Span processor adds extra browser attributes', () => {
-    windowSpy.mockImplementation(() => ({
-      location: {
-        hash: '#testing',
-        href: 'https://example.com/some-path#testing',
-        pathname: '/some-path',
-      },
-      innerWidth: 1720,
-      innerHeight: 1000,
-    }));
-
     browserAttrsSpanProcessor.onStart(span);
 
     expect(span.attributes).toEqual({
-      'browser.width': window.innerWidth,
-      'browser.height': window.innerHeight,
-      'page.hash': window.location.hash,
-      'page.url': window.location.href,
-      'page.route': window.location.pathname,
-      'page.hostname': window.location.hostname,
-      'page.search': window.location.search,
+      'browser.width': 1024,
+      'browser.height': 768,
+      'page.hash': '#the-hash',
+      'page.hostname': 'something-something.com',
+      'page.route': '/some-page',
+      'page.search': '?search_params=yes&hello=hi',
+      'page.url':
+        'http://something-something.com/some-page?search_params=yes&hello=hi#the-hash',
     });
   });
 });

--- a/test/span-processor-builder.test.ts
+++ b/test/span-processor-builder.test.ts
@@ -118,8 +118,8 @@ describe('configureSpanProcessors', () => {
 
     honeycombSpanProcessors.onStart(span, ROOT_CONTEXT);
     expect(span.attributes).toEqual({
-      'browser.width': window.screen.width,
-      'browser.height': window.screen.height,
+      'browser.width': window.innerWidth,
+      'browser.height': window.innerHeight,
       'browser.hash': window.location.hash,
       'browser.url': window.location.href,
       'browser.route': window.location.pathname,
@@ -147,8 +147,8 @@ describe('configureSpanProcessors', () => {
 
     honeycombSpanProcessors.onStart(span, ROOT_CONTEXT);
     expect(span.attributes).toEqual({
-      'browser.width': window.screen.width,
-      'browser.height': window.screen.height,
+      'browser.width': window.innerWidth,
+      'browser.height': window.innerHeight,
       'browser.hash': window.location.hash,
       'browser.url': window.location.href,
       'browser.route': window.location.pathname,

--- a/test/span-processor-builder.test.ts
+++ b/test/span-processor-builder.test.ts
@@ -1,0 +1,158 @@
+import {
+  CompositeSpanProcessor,
+  configureSpanProcessors,
+} from '../src/span-processor-builder';
+import {
+  BasicTracerProvider,
+  BatchSpanProcessor,
+  Span,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { ROOT_CONTEXT, SpanKind, TraceFlags } from '@opentelemetry/api';
+
+class TestSpanProcessorOne implements SpanProcessor {
+  onStart(span: Span): void {
+    span.setAttributes({
+      'processor1.name': 'TestSpanProcessorOne',
+    });
+  }
+
+  onEnd(): void {}
+
+  forceFlush() {
+    return Promise.resolve();
+  }
+
+  shutdown() {
+    return Promise.resolve();
+  }
+}
+
+class TestSpanProcessorTwo implements SpanProcessor {
+  onStart(span: Span): void {
+    span.setAttributes({
+      'processor2.name': 'TestSpanProcessorTwo',
+    });
+  }
+
+  onEnd(): void {}
+
+  forceFlush() {
+    return Promise.resolve();
+  }
+
+  shutdown() {
+    return Promise.resolve();
+  }
+}
+
+describe('CompositeSpanProcessor', () => {
+  const compositeSpanProcessor = new CompositeSpanProcessor();
+
+  let span: Span;
+
+  beforeEach(() => {
+    span = new Span(
+      new BasicTracerProvider().getTracer('browser-attrs-testing'),
+      ROOT_CONTEXT,
+      'A Very Important Browser Span!',
+      {
+        traceId: '',
+        spanId: '',
+        traceFlags: TraceFlags.SAMPLED,
+      },
+      SpanKind.CLIENT,
+    );
+  });
+
+  test('Combines multiple span processors', () => {
+    compositeSpanProcessor.addProcessor(new TestSpanProcessorOne());
+    compositeSpanProcessor.addProcessor(new TestSpanProcessorTwo());
+
+    compositeSpanProcessor.onStart(span, ROOT_CONTEXT);
+
+    expect(span.attributes).toEqual({
+      'processor1.name': 'TestSpanProcessorOne',
+      'processor2.name': 'TestSpanProcessorTwo',
+    });
+  });
+});
+
+describe('configureSpanProcessors', () => {
+  let span: Span;
+  let windowSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    windowSpy = jest.spyOn(globalThis, 'window', 'get');
+
+    span = new Span(
+      new BasicTracerProvider().getTracer('browser-attrs-testing'),
+      ROOT_CONTEXT,
+      'A Very Important Browser Span!',
+      {
+        traceId: '',
+        spanId: '',
+        traceFlags: TraceFlags.SAMPLED,
+      },
+      SpanKind.CLIENT,
+    );
+  });
+  test('Configures BatchSpanProcessor & BrowserAttributesSpanProcessor by default', () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        hash: '#testing',
+        href: 'https://example.com/some-path#testing',
+        pathname: '/some-path',
+      },
+      screen: {
+        width: 1440,
+        height: 982,
+      },
+    }));
+
+    const honeycombSpanProcessors = configureSpanProcessors({});
+    expect(honeycombSpanProcessors.getSpanProcessors()).toHaveLength(2);
+    expect(honeycombSpanProcessors.getSpanProcessors()[0]).toBeInstanceOf(
+      BatchSpanProcessor,
+    );
+
+    honeycombSpanProcessors.onStart(span, ROOT_CONTEXT);
+    expect(span.attributes).toEqual({
+      'browser.width': window.screen.width,
+      'browser.height': window.screen.height,
+      'browser.hash': window.location.hash,
+      'browser.url': window.location.href,
+      'browser.route': window.location.pathname,
+    });
+  });
+  test('Configures additional user provided span processor', () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        hash: '#testing',
+        href: 'https://example.com/some-path#testing',
+        pathname: '/some-path',
+      },
+      screen: {
+        width: 1440,
+        height: 982,
+      },
+    }));
+    const honeycombSpanProcessors = configureSpanProcessors({
+      spanProcessor: new TestSpanProcessorOne(),
+    });
+    expect(honeycombSpanProcessors.getSpanProcessors()).toHaveLength(3);
+    expect(honeycombSpanProcessors.getSpanProcessors()[0]).toBeInstanceOf(
+      BatchSpanProcessor,
+    );
+
+    honeycombSpanProcessors.onStart(span, ROOT_CONTEXT);
+    expect(span.attributes).toEqual({
+      'browser.width': window.screen.width,
+      'browser.height': window.screen.height,
+      'browser.hash': window.location.hash,
+      'browser.url': window.location.href,
+      'browser.route': window.location.pathname,
+      'processor1.name': 'TestSpanProcessorOne',
+    });
+  });
+});

--- a/test/span-processor-builder.test.ts
+++ b/test/span-processor-builder.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment-options {"url": "http://something-something.com/some-page?search_params=yes&hello=hi#the-hash"}
+ */
 import {
   CompositeSpanProcessor,
   configureSpanProcessors,
@@ -80,11 +83,8 @@ describe('CompositeSpanProcessor', () => {
 
 describe('configureSpanProcessors', () => {
   let span: Span;
-  let windowSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    windowSpy = jest.spyOn(globalThis, 'window', 'get');
-
     span = new Span(
       new BasicTracerProvider().getTracer('browser-attrs-testing'),
       ROOT_CONTEXT,
@@ -98,16 +98,6 @@ describe('configureSpanProcessors', () => {
     );
   });
   test('Configures BatchSpanProcessor & BrowserAttributesSpanProcessor by default', () => {
-    windowSpy.mockImplementation(() => ({
-      location: {
-        hash: '#testing',
-        href: 'https://example.com/some-path#testing',
-        pathname: '/some-path',
-      },
-      innerWidth: 1720,
-      innerHeight: 1000,
-    }));
-
     const honeycombSpanProcessors = configureSpanProcessors({});
     expect(honeycombSpanProcessors.getSpanProcessors()).toHaveLength(2);
     expect(honeycombSpanProcessors.getSpanProcessors()[0]).toBeInstanceOf(
@@ -116,25 +106,17 @@ describe('configureSpanProcessors', () => {
 
     honeycombSpanProcessors.onStart(span, ROOT_CONTEXT);
     expect(span.attributes).toEqual({
-      'browser.width': window.innerWidth,
-      'browser.height': window.innerHeight,
-      'page.hash': window.location.hash,
-      'page.url': window.location.href,
-      'page.route': window.location.pathname,
-      'page.hostname': window.location.hostname,
-      'page.search': window.location.search,
+      'browser.width': 1024,
+      'browser.height': 768,
+      'page.hash': '#the-hash',
+      'page.hostname': 'something-something.com',
+      'page.route': '/some-page',
+      'page.search': '?search_params=yes&hello=hi',
+      'page.url':
+        'http://something-something.com/some-page?search_params=yes&hello=hi#the-hash',
     });
   });
   test('Configures additional user provided span processor', () => {
-    windowSpy.mockImplementation(() => ({
-      location: {
-        hash: '#testing',
-        href: 'https://example.com/some-path#testing',
-        pathname: '/some-path',
-      },
-      innerWidth: 1720,
-      innerHeight: 1000,
-    }));
     const honeycombSpanProcessors = configureSpanProcessors({
       spanProcessor: new TestSpanProcessorOne(),
     });
@@ -145,13 +127,14 @@ describe('configureSpanProcessors', () => {
 
     honeycombSpanProcessors.onStart(span, ROOT_CONTEXT);
     expect(span.attributes).toEqual({
-      'browser.width': window.innerWidth,
-      'browser.height': window.innerHeight,
-      'page.hash': window.location.hash,
-      'page.url': window.location.href,
-      'page.route': window.location.pathname,
-      'page.hostname': window.location.hostname,
-      'page.search': window.location.search,
+      'browser.width': 1024,
+      'browser.height': 768,
+      'page.hash': '#the-hash',
+      'page.hostname': 'something-something.com',
+      'page.route': '/some-page',
+      'page.search': '?search_params=yes&hello=hi',
+      'page.url':
+        'http://something-something.com/some-page?search_params=yes&hello=hi#the-hash',
       'processor1.name': 'TestSpanProcessorOne',
     });
   });

--- a/test/span-processor-builder.test.ts
+++ b/test/span-processor-builder.test.ts
@@ -104,10 +104,8 @@ describe('configureSpanProcessors', () => {
         href: 'https://example.com/some-path#testing',
         pathname: '/some-path',
       },
-      screen: {
-        width: 1440,
-        height: 982,
-      },
+      innerWidth: 1720,
+      innerHeight: 1000,
     }));
 
     const honeycombSpanProcessors = configureSpanProcessors({});
@@ -120,9 +118,11 @@ describe('configureSpanProcessors', () => {
     expect(span.attributes).toEqual({
       'browser.width': window.innerWidth,
       'browser.height': window.innerHeight,
-      'browser.hash': window.location.hash,
-      'browser.url': window.location.href,
-      'browser.route': window.location.pathname,
+      'page.hash': window.location.hash,
+      'page.url': window.location.href,
+      'page.route': window.location.pathname,
+      'page.hostname': window.location.hostname,
+      'page.search': window.location.search,
     });
   });
   test('Configures additional user provided span processor', () => {
@@ -132,10 +132,8 @@ describe('configureSpanProcessors', () => {
         href: 'https://example.com/some-path#testing',
         pathname: '/some-path',
       },
-      screen: {
-        width: 1440,
-        height: 982,
-      },
+      innerWidth: 1720,
+      innerHeight: 1000,
     }));
     const honeycombSpanProcessors = configureSpanProcessors({
       spanProcessor: new TestSpanProcessorOne(),
@@ -149,9 +147,11 @@ describe('configureSpanProcessors', () => {
     expect(span.attributes).toEqual({
       'browser.width': window.innerWidth,
       'browser.height': window.innerHeight,
-      'browser.hash': window.location.hash,
-      'browser.url': window.location.href,
-      'browser.route': window.location.pathname,
+      'page.hash': window.location.hash,
+      'page.url': window.location.href,
+      'page.route': window.location.pathname,
+      'page.hostname': window.location.hostname,
+      'page.search': window.location.search,
       'processor1.name': 'TestSpanProcessorOne',
     });
   });


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
This PR adds the `BrowserAttributesSpanProcessor` which adds rich browser attributes to every span. Attributes like the page location and screen height and width might change during the lifecycle of a session so they are better captured through a Span Processor rather than on the Resource.

- Closes #11 

## Short description of the changes
- `BrowserAttributesSpanProcessor` class that adds attributes to each span
- `CompositeSpanProcessor` class that combines multiple span processors together since the base SDK does not support multiple span processors
- Span processor builder that configures the `BatchSpanProcessor` with the exporter as well as the `BrowserAttributesSpanProcessor` and an optional user provided span processor
- Had to switch the exporter being configured through this span processor builder since the base SDK does not support configuring an exporter through the `traceExporter` option if a `spanProcessor` is provided.

## How to verify that this has the expected result
- Run the test app and check for the additional browser attributes
- The data should still be exported to Honeycomb
