### PR TITLE
maint: add mini smoke test to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,21 @@ jobs:
       - store_artifacts:
           path: ./reports/
 
+  smoke_test:
+    machine:
+      image: ubuntu-2004:202107-02
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+        name: Spin up example app
+        command: docker build -t smoke-tests . && docker run -dp 127.0.0.1:3000:3000 --name smoke-tests smoke-tests
+      - run:
+        name: Spin down example app
+        command: docker stop smoke-tests && docker rm smoke-tests
+
+
   publish_github:
     executor: github
     steps:
@@ -95,6 +110,10 @@ workflows:
           <<: *filters_always
           requires:
             - test
+      - smoke_test:
+          <<: *filters_always
+          requires:
+            - build
       - publish_github:
           <<: *filters_publish
           context: Honeycomb Secrets for Public Repos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,11 +72,11 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
-        name: Spin up example app
-        command: docker build -t smoke-tests . && docker run -dp 127.0.0.1:3000:3000 --name smoke-tests smoke-tests
+          name: Spin up example app
+          command: docker build -t smoke-tests . && docker run -dp 127.0.0.1:3000:3000 --name smoke-tests smoke-tests
       - run:
-        name: Spin down example app
-        command: docker stop smoke-tests && docker rm smoke-tests
+          name: Spin down example app
+          command: docker stop smoke-tests && docker rm smoke-tests
 
 
   publish_github:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
 
   smoke_test:
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2004:2023.04.1
     steps:
       - checkout
       - attach_workspace:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 node_modules
 examples/hello-world-web/node_modules
+build
+dist
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18-bullseye
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
## Which problem is this PR solving?

- ensure apps build properly on every commit

## Short description of the changes

- add mini smoke test to CI that just ensures the app can build and run without error

## How to verify that this has the expected result

run these locally and it should build fine, change the auto-instrumentations-web version to 0.35 and see it error. Actually we should see this fail in dependabots too until the fix comes out for auto-instrumentations.

Note this is a temporary stopgap to catch errors before we finish implementing #17 