### PR TITLE
rel: prep release 0.0.1 alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
-# {project-name} changelog
+# honeycomb-opentelemetry-web changelog
 
+## v0.0.1 [alpha] - 2024-01-31
+
+🎉 Initial alpha release of Honeycomb's OpenTelemetry Web Distro! 🎉

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) in the browser.
 
 Latest release:
 
-* built with OpenTelemetry JS [Stable v1.18.1](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.18.1), [Experimental v0.45.1](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.45.1), [API v1.7.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/api%2Fv1.7.0)
-* compatible with OpenTelemetry Auto-Instrumentations for Web [~0.33.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-node-v0.33.0)
+* built with OpenTelemetry JS [Stable v1.21.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.21.0), [Experimental v0.48.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.48.0), [API v1.7.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/api%2Fv1.7.0)
+* compatible with OpenTelemetry Auto-Instrumentations for Web [~0.36.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-node-v0.36.0)
 
 This package sets up OpenTelemetry for tracing, using our recommended practices, including:
 


### PR DESCRIPTION
## Which problem is this PR solving?

- lack of a published release!

## Short description of the changes

- update changelog for first alpha release
- update readme with current versions of otel
- note: version was already set to 0.0.1, so no changes needed there

## How to verify that this has the expected result

- after merging we should be able to tag and release the first alpha version