### PR TITLE
fix(ci): update publish steps to depend on smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,8 +138,10 @@ workflows:
           context: Honeycomb Secrets for Public Repos
           requires:
             - build
+            - smoke_test
       - publish_npm:
           <<: *filters_publish
           context: Honeycomb Secrets for Public Repos
           requires:
             - build
+            - smoke_test


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #59 

Currently, [smoke tests run in parallel](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-web/136/workflows/492c3294-d552-4f4f-9cbc-ee6685ace476) to our publish steps. We want publish steps to depend on smoke tests so that if they fail, a package does not get published.

## Short description of the changes
- Change publish steps to depend on smoke tests in CI config.

## How to verify that this has the expected result
- This will only be verifiable on our next release. This is really similar to our setup in the [Node distro](https://github.com/honeycombio/honeycomb-opentelemetry-node/blob/main/.circleci/config.yml#L145).
