### PR TITLE
docs: web vitals config & event attributes

### DIFF
--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -2,13 +2,13 @@
 
 By default, Honeycomb includes events for all web vitals except first-input-delay. First-input-delay is set to be replaced by interaction-to-next-paint as a core web vital in March 2024.
 
-## Metric Attributes
+## Vitals Attributes
 
-All metrics have the following attributes: `web_vital.name`, `web_vital.rating`, `web_vital.id`
+All vitals have the following attributes: `web_vital.name`, `web_vital.rating`, `web_vital.id`
 
 ```
 /**
- * The name of the metric (in acronym form).
+ * The name of the vital (in acronym form).
  */
 "web_vital.name": 'CLS' | 'FCP' | 'INP' | 'LCP' | 'TTFB';
 
@@ -24,7 +24,7 @@ All metrics have the following attributes: `web_vital.name`, `web_vital.rating`,
  * metric instance, or to group multiple deltas together and calculate a
  * total. It can also be used to differentiate multiple different metric
  * instances sent from the same page, which can happen if the page is
- * restored from the back/forward cache (in that case new metrics object
+ * restored from the back/forward cache (in that case new vital object
  * get created).
  */
 

--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -1,6 +1,6 @@
 # Web Vitals
 
-By default, Honeycomb includes events for all web vitals except first-input-delay. First-input-delay is set to be replaced by interaction-to-next-paint as a core web vital in March 2024.
+By default, Honeycomb includes events for all web vitals except [first-input-delay](https://web.dev/articles/fid). First-input-delay is set to be replaced by interaction-to-next-paint as a core web vital in March 2024.
 
 ## Vitals Attributes
 

--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -32,7 +32,7 @@ All metrics have the following attributes: `web_vital.name`, `web_vital.rating`,
 
 ```
 
-### Cumulative Layout Score attributes
+### [Cumulative Layout Score](https://web.dev/articles/cls) attributes
 
 ```
 /* Shared fields */
@@ -84,7 +84,7 @@ All metrics have the following attributes: `web_vital.name`, `web_vital.rating`,
 
 The event time is when the single largest layout shift contributing to the page's CLS score occurred. (performance.timeOrigin + metric.largestShiftTime)
 
-### Largest Contentful Paint attributes
+### [Largest Contentful Paint](https://web.dev/articles/lcp) attributes
 
 ```
 /** Shared fields */
@@ -141,7 +141,7 @@ The event time is when the single largest layout shift contributing to the page'
 
 The event time is the start of the page load (performance.timeOrigin), the duration is equivalent to "lcp.value"
 
-### Interaction to Next Paint attributes
+### [Interaction to Next Paint](https://web.dev/articles/optimize-inp) attributes
 
 ```
 /** Shared fields */
@@ -182,7 +182,7 @@ The event time is the start of the page load (performance.timeOrigin), the durat
 
 The event time is equal to the time the interaction began {[TODO] `attribution.eventTime + performance.timeOrigin`? or just `attribution.eventTime`}, the duration is equal to `inp.value`
 
-### First Contentful Paint attributes
+### [First Contentful Paint](https://web.dev/articles/fcp) attributes
 
 ```
 /** Shared fields */
@@ -216,10 +216,9 @@ The event time is equal to the time the interaction began {[TODO] `attribution.e
 
 The event time is equal to the start of the page load, the duration is equal to `fcp.value`
 
-### Time to First Byte attributes
+### [Time to First Byte](https://web.dev/articles/ttfb) attributes
 
 ```
-
 /** Shared fields */
 "web_vital.name": "TTFB",
 "web_vital.rating": "good" | "needs-improvement" | "poor",

--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -6,7 +6,7 @@ By default, Honeycomb includes events for all web vitals except first-input-dela
 
 All metrics have the following attributes: `web_vital.name`, `web_vital.rating`, `web_vital.id`
 
-```
+```ts
 /**
  * The name of the metric (in acronym form).
  */
@@ -29,12 +29,11 @@ All metrics have the following attributes: `web_vital.name`, `web_vital.rating`,
  */
 
 "web_vital.id": string;
-
 ```
 
 ### [Cumulative Layout Score](https://web.dev/articles/cls) attributes
 
-```
+```ts
 /* Shared fields */
 "web_vital.name": "CLS",
 "web_vital.rating": "good" | "needs-improvement" | "poor",
@@ -45,6 +44,7 @@ All metrics have the following attributes: `web_vital.name`, `web_vital.rating`,
 "cls.value": number;
 "cls.delta": number;
 
+ /**
  * A selector identifying the first element (in document order) that
  * shifted when the single largest layout shift contributing to the page's
  * CLS score occurred.
@@ -86,7 +86,7 @@ The event time is when the single largest layout shift contributing to the page'
 
 ### [Largest Contentful Paint](https://web.dev/articles/lcp) attributes
 
-```
+```ts
 /** Shared fields */
 "web_vital.name": "LCP",
 "web_vital.rating": "good" | "needs-improvement" | "poor",
@@ -109,7 +109,7 @@ The event time is when the single largest layout shift contributing to the page'
  */
 "lcp.url": string;
 
-**
+/**
  * The time from when the user initiates loading the page until when the
  * browser receives the first byte of the response (a.k.a. TTFB). See
  * [Optimize LCP](https://web.dev/articles/optimize-lcp) for details.
@@ -143,7 +143,7 @@ The event time is the start of the page load (performance.timeOrigin), the durat
 
 ### [Interaction to Next Paint](https://web.dev/articles/optimize-inp) attributes
 
-```
+```ts
 /** Shared fields */
 "web_vital.name": "INP",
 "web_vital.rating": "good" | "needs-improvement" | "poor",
@@ -184,7 +184,7 @@ The event time is equal to the time the interaction began {[TODO] `attribution.e
 
 ### [First Contentful Paint](https://web.dev/articles/fcp) attributes
 
-```
+```ts
 /** Shared fields */
 "web_vital.name": "FCP",
 "web_vital.rating": "good" | "needs-improvement" | "poor",
@@ -218,7 +218,7 @@ The event time is equal to the start of the page load, the duration is equal to 
 
 ### [Time to First Byte](https://web.dev/articles/ttfb) attributes
 
-```
+```js
 /** Shared fields */
 "web_vital.name": "TTFB",
 "web_vital.rating": "good" | "needs-improvement" | "poor",
@@ -258,7 +258,7 @@ The event time is equal to the timeOrigin & the duration is equal to ttfb.value
 
 For more fine-tuned event processing, pass in a custom callback functions for each of the web-vitals:
 
-```
+```js
 
 const sdk = new HoneycombWebSDK({
   webVitals: {
@@ -270,7 +270,7 @@ const sdk = new HoneycombWebSDK({
 
 Supported fields:
 
-```
+```ts
 onCLS?: CLSReportCallbackWithAttribution;
 onFCP?: FCPReportCallbackWithAttribution;
 onFID?: FIDReportCallbackWithAttribution;
@@ -339,7 +339,7 @@ const sdk = new HoneycombWebSDK({
 
 ## Config Options
 
-```
+```ts
 interface WebVitalsConfig {
   elementDataAttribute?: string;
   reportOptions?: {

--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -1,0 +1,363 @@
+# Web Vitals
+
+By default, Honeycomb includes events for all web vitals except first-input-delay. First-input-delay is set to be replaced by interaction-to-next-paint as a core web vital in March 2024.
+
+## Metric Attributes
+
+All metrics have the following attributes: `web_vital.name`, `web_vital.rating`, `web_vital.id`
+
+```
+/**
+ * The name of the metric (in acronym form).
+ */
+"web_vital.name": 'CLS' | 'FCP' | 'INP' | 'LCP' | 'TTFB';
+
+/**
+ * The rating as to whether the metric value is within the "good",
+ * "needs improvement", or "poor" thresholds of the metric.
+ */
+"web_vital.rating": "good" | "needs-improvement" | "poor"
+
+/**
+ * A unique ID representing this particular metric instance. This ID can
+ * be used by an analytics tool to dedupe multiple values sent for the same
+ * metric instance, or to group multiple deltas together and calculate a
+ * total. It can also be used to differentiate multiple different metric
+ * instances sent from the same page, which can happen if the page is
+ * restored from the back/forward cache (in that case new metrics object
+ * get created).
+ */
+
+"web_vital.id": string;
+
+```
+
+### Cumulative Layout Score attributes
+
+```
+/* Shared fields */
+"web_vital.name": "CLS",
+"web_vital.rating": "good" | "needs-improvement" | "poor",
+"web_vital.id": string;
+
+
+/* CLS specific fields */
+"cls.value": number;
+"cls.delta": number;
+
+ * A selector identifying the first element (in document order) that
+ * shifted when the single largest layout shift contributing to the page's
+ * CLS score occurred.
+ */
+"cls.largest_shift_target": string
+
+/* if available, the data-attribute on the largest shift target. Otherwise, an alias for cls.largest_shift_target */
+"cls.element": attribution.largestShiftTarget
+
+/**
+ * The time when the single largest layout shift contributing to the page's
+ * CLS score occurred. The number of milliseconds elapsed since navigation.
+ * [OPEN QUESTION] should this be cls.elapsed_time? or have something as an
+ * alias? it records the ms since navigation (performance.timeOrigin) — it
+ * isn't a timestamp as a DateTime
+ */
+"cls.largest_shift_time": DOMHighResTimeStamp;
+
+/**
+ * The layout shift score of the single largest layout shift contributing to
+ * the page's CLS score.
+ */
+"cls.largest_shift_value": number;
+
+/**
+ * The loading state of the document at the time when the largest layout
+ * shift contribution to the page's CLS score occurred (see
+ * https://github.com/GoogleChrome/web-vitals?tab=readme-ov-file#loadstate
+ * for details).
+ */
+"cls.load_state": LoadState
+
+/* attribution.largestShiftEntry.hadRecentInput */
+"cls.had_recent_input": boolean;
+
+```
+
+The event time is when the single largest layout shift contributing to the page's CLS score occurred. (performance.timeOrigin + metric.largestShiftTime)
+
+### Largest Contentful Paint attributes
+
+```
+/** Shared fields */
+"web_vital.name": "LCP",
+"web_vital.rating": "good" | "needs-improvement" | "poor",
+"web_vital.id": string;
+
+/** LCP specific fields */
+
+"lcp.value": number;
+"lcp.delta": number;
+
+/**
+* if available, the data attribute on the element corresponding to the largest
+* contentful paint for the page. Otherwise, its selector.
+*/
+"lcp.element": string;
+
+/**
+ * The URL (if applicable) of the LCP image resource. If the LCP element
+ * is a text node, this value will not be set.
+ */
+"lcp.url": string;
+
+**
+ * The time from when the user initiates loading the page until when the
+ * browser receives the first byte of the response (a.k.a. TTFB). See
+ * [Optimize LCP](https://web.dev/articles/optimize-lcp) for details.
+ */
+
+"lcp.time_to_first_byte": number;
+/**
+ * The delta between TTFB and when the browser starts loading the LCP
+ * resource (if there is one, otherwise 0). See [Optimize
+ * LCP](https://web.dev/articles/optimize-lcp) for details.
+ */
+"lcp.resource_load_delay": number;
+
+/**
+ * The total time it takes to load the LCP resource itself (if there is one,
+ * otherwise 0). See [Optimize LCP](https://web.dev/articles/optimize-lcp) for
+ * details.
+ */
+"lcp.resource_load_time": number;
+
+/**
+ * The delta between when the LCP resource finishes loading until the LCP
+ * element is fully rendered. See [Optimize
+ * LCP](https://web.dev/articles/optimize-lcp) for details.
+ */
+"lcp.element_render_delay": number;
+
+```
+
+The event time is the start of the page load (performance.timeOrigin), the duration is equivalent to "lcp.value"
+
+### Interaction to Next Paint attributes
+
+```
+/** Shared fields */
+"web_vital.name": "INP",
+"web_vital.rating": "good" | "needs-improvement" | "poor",
+"web_vital.id": string;
+
+/** INP specific fields */
+
+/* How long from the user interaction until the next paint */
+"inp.value": number;
+"inp.delta": number;
+
+/**
+ *
+ * Either a selector identifying the element that the user interacted with for
+ * the event corresponding to INP or its data-attribute (when `dataAttribute`
+ * option is set in the config). This element will be the `target` of the
+ * `event` dispatched.
+ */
+"inp.element": string;
+
+/**
+ * The `type` of the `event` dispatched corresponding to INP.
+ */
+"inp.event_type": string;
+
+/**
+ * The loading state of the document at the time when the event corresponding
+ * to INP occurred (see `LoadState` for details). If the interaction occurred
+ * while the document was loading and executing script (e.g. usually in the
+ * `dom-interactive` phase) it can result in long delays.
+ */
+"inp.load_state": LoadState;
+}
+
+```
+
+The event time is equal to the time the interaction began {[TODO] `attribution.eventTime + performance.timeOrigin`? or just `attribution.eventTime`}, the duration is equal to `inp.value`
+
+### First Contentful Paint attributes
+
+```
+/** Shared fields */
+"web_vital.name": "FCP",
+"web_vital.rating": "good" | "needs-improvement" | "poor",
+"web_vital.id": string;
+
+/** FCP specific fields */
+
+"fcp.value": number;
+"fcp.delta": number;
+/**
+ * The time from when the user initiates loading the page until when the
+ * browser receives the first byte of the response (a.k.a. TTFB).
+ */
+"fcp.time_to_first_byte": number;
+
+/**
+ * The delta between TTFB and the first contentful paint (FCP).
+ */
+"fcp.time_since_first_byte": number;
+
+/**
+ * The loading state of the document at the time when FCP `occurred (see
+ * `LoadState` for details). Ideally, documents can paint before they finish
+ * loading (e.g. the `loading` or `dom-interactive` phases).
+ */
+"fcp.load_state": LoadState;
+
+```
+
+The event time is equal to the start of the page load, the duration is equal to `fcp.value`
+
+### Time to First Byte attributes
+
+```
+
+/** Shared fields */
+"web_vital.name": "TTFB",
+"web_vital.rating": "good" | "needs-improvement" | "poor",
+"web_vital.id": string;
+
+/** TTFB specific fields */
+
+"ttfb.value": number;
+"ttfb.delta": number;
+
+/**
+ * The total time from when the user initiates loading the page to when the
+ * DNS lookup begins. This includes redirects, service worker startup, and
+ * HTTP cache lookup times.
+ */
+"ttfb.waiting_time": number;
+/**
+ * The total time to resolve the DNS for the current request.
+ */
+"ttfb.dns_time": number;
+/**
+ * The total time to create the connection to the requested domain.
+ */
+"ttfb.connection_time": number;
+/**
+ * The time time from when the request was sent until the first byte of the
+ * response was received. This includes network time as well as server
+ * processing time.
+ */
+"ttfb.request_time": number;
+
+```
+
+The event time is equal to the timeOrigin & the duration is equal to ttfb.value
+
+## Customization of event attributes
+
+For more fine-tuned event processing, pass in a custom callback functions for each of the web-vitals:
+
+```
+
+const sdk = new HoneycombWebSDK({
+  webVitals: {
+    onCLS: (clsWithAttribution) => {//custom event processor },
+  }
+});
+
+```
+
+Supported fields:
+
+```
+onCLS?: CLSReportCallbackWithAttribution;
+onFCP?: FCPReportCallbackWithAttribution;
+onFID?: FIDReportCallbackWithAttribution;
+onINP?: INPReportCallbackWithAttribution;
+onLCP?: LCPReportCallbackWithAttribution;
+onTTFB?: TTFBReportCallbackWithAttribution;
+
+```
+
+The callbacks are passed their respective metric with attribution. [web-vitals docs](https://github.com/GoogleChrome/web-vitals?tab=readme-ov-file#metricwithattribution)
+
+**Note**: passing in a custom callback will _replace_ the default attributes provided by this package, not augment.
+
+## Additional Configuration
+
+### Using custom data attribute to identify elements
+
+Sometimes the element selector (used by LCP, INP & CLS events) is not very human-readable (or changes frequently) & makes it difficult to figure out the actual culprit. Pass in a custom data selector & hny will use that identifier instead for the `lcp.element`, `cls.element` & `inp.element` attributes.
+
+```js
+const sdk = new HoneycombWebSDK({
+  serviceName: 'my-app',
+  webVitals: {
+    elementDataAttribute: 'human-id',
+  },
+});
+```
+
+```html
+<input type="color" class="css-1rjml27" data-human-id="favorite-color-picker" />
+```
+
+Example INP event:
+
+```js
+{
+  "web_vital.name: "inp",
+  "inp.element": "favorite-color-picker",
+  // other fields
+}
+```
+
+### Including the metric value in `web_vital.value` attribute
+
+By default, each metric value is namespaced under the metric name, `lcp.value` | `cls.value` | `inp.value`, etc. Chose to include the value in `web_vital.value` attribute:
+
+```js
+const sdk = new HoneycombWebSDK({
+  serviceName: 'my-app',
+  webVitals: {
+    includeValueInTopLevelNamespace: true,
+  },
+});
+```
+
+## Disable web vitals reporting
+
+To disable collection of web vitals, set `webVitals` to false in the config
+
+```js
+const sdk = new HoneycombWebSDK({
+  serviceName: 'my-app',
+  webVitals: false,
+});
+```
+
+## Config Options
+
+```
+interface WebVitalsConfig {
+  elementDataAttribute?: string;
+  reportOptions?: {
+    reportAllChanges?: boolean;
+    durationThreshold?: number;
+  };
+  onCLS?: CLSReportCallbackWithAttribution;
+  onFCP?: FCPReportCallbackWithAttribution;
+  onFID?: FIDReportCallbackWithAttribution;
+  onINP?: INPReportCallbackWithAttribution;
+  onLCP?: LCPReportCallbackWithAttribution;
+  onTTFB?: TTFBReportCallbackWithAttribution;
+
+  /** Whether or not the metric's value should be sent as
+   * `web_vital.value` as well as `[metricName].value`, ie `lcp.value`.
+   * Defaults to false */
+  includeValueInTopLevelNamespace?: boolean;
+}
+
+```

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,10 +106,10 @@ interface WebVitalsConfig {
     reportAllChanges?: boolean;
     durationThreshold?: number;
   };
-  onCLS?: CLSReportCallbackWithAttribution;
-  onFCP?: FCPReportCallbackWithAttribution;
-  onFID?: FIDReportCallbackWithAttribution;
-  onINP?: INPReportCallbackWithAttribution;
-  onLCP?: LCPReportCallbackWithAttribution;
-  onTTFB?: TTFBReportCallbackWithAttribution;
+  // onCLS?: CLSReportCallbackWithAttribution;
+  // onFCP?: FCPReportCallbackWithAttribution;
+  // onFID?: FIDReportCallbackWithAttribution;
+  // onINP?: INPReportCallbackWithAttribution;
+  // onLCP?: LCPReportCallbackWithAttribution;
+  // onTTFB?: TTFBReportCallbackWithAttribution;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,4 +95,21 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
    * TODO: Not yet implemented
    */
   // skipOptionsValidation?: boolean;
+  //
+
+  webVitals?: false | WebVitalsConfig;
+}
+
+interface WebVitalsConfig {
+  elementDataAttribute?: string;
+  reportOptions?: {
+    reportAllChanges?: boolean;
+    durationThreshold?: number;
+  };
+  onCLS?: CLSReportCallbackWithAttribution;
+  onFCP?: FCPReportCallbackWithAttribution;
+  onFID?: FIDReportCallbackWithAttribution;
+  onINP?: INPReportCallbackWithAttribution;
+  onLCP?: LCPReportCallbackWithAttribution;
+  onTTFB?: TTFBReportCallbackWithAttribution;
 }


### PR DESCRIPTION
## Short description of the changes
Adds documentation for proposed web vitals config & span attributes for each vital: to kickstart discussion & align prior to writing the actual implementation code. living that [readme-driven-development](https://tom.preston-werner.com/2010/08/23/readme-driven-development.html) dream

[Formatted Web Vitals readme](https://github.com/honeycombio/honeycomb-opentelemetry-web/blob/ahr/vitals-readme/docs/web-vitals.md)

## Summary/overview

### Event Fields
**Namespacing**
Moves most of the individual attributes out of the `web_vital.` namespace & into the respective metric's acronym, `cls.value | lcp.value | inp.value | fcp.value | ttfb.value`.

Benefits to namespacing under the individual acronoym instead of a shared `web_vital`: when adding filters or group-bys, I've found it nice to have confidence I'm using a field that's actually relevant for the specific metric I'm digging into 

**Why not keep the web_vital namespace & have nested keys, a la `web_vital.cls.largest_shift_entry`**? We could do that! But for brevity's sake, both in UI display (long field names are a bear) as well as saving folks those extra key strokes. I reckon each vital has enough custom fields to warrant top-level namespace

Universal fields on all web vitals: `web_vital.name`, `web_vital.rating`, `web_vital.id`

For metrics which include reference to a specific element — largest contentful paint, cumulative layout score, interaction to next paint — that element is always included in `[metric].element`, instead of a metric-specific key (`inp.element` instead of `inp.event_target`, `cls.element` instead of `cls.largest_shift_target`. `lcp.element` remains `lcp.element`). Although we do lose specific signal around _why_ the element is being referenced, I think there's benefit to folks only needing to remember one field name. Each metric has only one specific, metric-related reason for referencing an element; I don't think we're losing too much signal by shedding the specificity in the key.

**Element attribution**
Adds a config field, `elementDataAttribute`, to let folks set a [custom data attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*) we'll look for when determining the element id. The web-vitals library uses the css selector, which is not always legible or consistent between builds (our telemetry has a bunch of `inp.event_target` that look like `div>div.css-bncyh0>div.css-1diydk0>div.fs-unmask.css-tcu5wm>a.css-1otlhad>h4.css-q2y3yl.css-bgrgbw`—good luck figuring out what _that_ corresponds to).

The readme right now has the same field, `[metric].element`, reference either the custom data attribute, if available, _or_ the web-vitals provided selector. I think there's arguably value in including both the data attribute (when available) _and_ the selector in individual fields.
Some options:

1. one field, `[metric].element`: data-attribute || selector
2. two distinct fields: `[metric].element.attribute`: data attribute `[metric].element.selecor`: the selector
   3). all the fields: `[metric].element`: data-attribute || selector, `[metric].element.attribute`: data attribute `[metric].element.selecor`: the selector

Option 3 could be handled by derived columns, but I like the idea of providing easily-queryable fields from jump.

**Event Timestamp & Duration**
When the metric has fields which correspond to an event timestamp & duration, use those values

CLS: Event time: `performance.timeOrigin + attribution.largestShiftTime`. duration n/a
LCP: Event time: `performance.timeOrigin`. Duration: `metric.value`
INP: Event time: `attribution.eventTime`. Duration: `metric.value`
FCP: Event time: `performance.timeOrigin`. Duration: `metric.value`
TTFB: Event time: `performance.timeOrigin`. Duration: `metric.value`


### Config Options
Allow disabling web vitals collection; accept custom event handlers for each of the web vitals as an escape hatch when folks need more control; allow specification of a custom data attribute for element attribution; option to keep the `[metric].value` in the `web_vital` namespace (ie `inp.value` => `web_vital.value`)


