### PR TITLE
feat: allow custom override of entry page attributes

### DIFF
--- a/src/entry-page-resource.ts
+++ b/src/entry-page-resource.ts
@@ -1,18 +1,55 @@
 import { Resource } from '@opentelemetry/resources';
+import { EntryPageConfig } from './types';
 
-export function configureEntryPageResource(): Resource {
-  let attributes = {};
-  if (window?.location) {
-    const { href, pathname, search, hash, hostname } = window.location;
-    attributes = {
-      'entry_page.url': href,
-      'entry_page.path': pathname,
-      'entry_page.search': search,
-      'entry_page.hash': hash,
-      'entry_page.hostname': hostname,
-      'entry_page.referrer': document.referrer,
-    };
+export const defaultConfig: EntryPageConfig = {
+  path: true,
+  hash: true,
+  hostname: true,
+  referrer: true,
+  url: false,
+  search: false,
+};
+
+export function configureEntryPageResource(
+  config?: EntryPageConfig | false,
+): Resource {
+  if (config === false || !window?.location) {
+    return new Resource({});
   }
 
+  const options = getOptions(config);
+  const { href, pathname, search, hash, hostname } = window.location;
+
+  const attributes = {
+    'entry_page.url': optionalAttribute(options.url, href),
+    'entry_page.path': optionalAttribute(options.path, pathname),
+    'entry_page.search': optionalAttribute(options.search, search),
+    'entry_page.hash': optionalAttribute(options.hash, hash),
+    'entry_page.hostname': optionalAttribute(options.hostname, hostname),
+    'entry_page.referrer': optionalAttribute(
+      options.referrer,
+      document.referrer,
+    ),
+  };
+
   return new Resource(attributes);
+}
+
+function getOptions(config?: EntryPageConfig) {
+  if (!config) {
+    return defaultConfig;
+  }
+
+  return { ...defaultConfig, ...config };
+}
+
+function optionalAttribute<T>(
+  shouldInclude: undefined | boolean,
+  attribute: T,
+): undefined | T {
+  if (!shouldInclude) {
+    return undefined;
+  }
+
+  return attribute;
 }

--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -12,7 +12,6 @@ export class HoneycombWebSDK extends WebSDK {
     super({
       ...options,
       resource: mergeResources([
-        configureEntryPageResource(),
         configureBrowserAttributesResource(),
         configureEntryPageResource(options?.entryPageAttributes),
         options?.resource,

--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -14,6 +14,7 @@ export class HoneycombWebSDK extends WebSDK {
       resource: mergeResources([
         configureEntryPageResource(),
         configureBrowserAttributesResource(),
+        configureEntryPageResource(options?.entryPageAttributes),
         options?.resource,
         configureHoneycombResource(),
       ]),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-// This code will eventually be packaged upstream into a WebSDK package.
 // Once it is released as a package, this distro will depend directly on the upstream package.
 // https://github.com/open-telemetry/opentelemetry-js/pull/4325
 /*
@@ -95,4 +94,51 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
    * TODO: Not yet implemented
    */
   // skipOptionsValidation?: boolean;
+
+  /** Configuration for entry page attributes: set to false to disable entirely, or pass in a custom config
+   * to fine-tune the included attributes.
+   *
+   * Defaults to
+   * ```
+   * {
+   *  path: true,
+   *  hash: true,
+   *  hostname: true,
+   *  referrer: true,
+   *  url: false,
+   *  search: false
+   * }
+   * ```
+   */
+  entryPageAttributes?: false | EntryPageConfig;
 }
+
+/* Configure which fields to include in the `entry_page` resource attributes. By default,
+ * does not include attributes that could expose search params (url, search) */
+export type EntryPageConfig = {
+  /** Include the path: '/working-with-your-data/overview/'
+   * Defaults to 'true' */
+  path?: boolean;
+
+  /** Include the hash: '#view-events'
+   * Defaults to 'true' */
+  hash?: boolean;
+
+  /** Include the hostname: 'docs.honeycomb.io'
+   * Defaults to 'true' */
+  hostname?: boolean;
+
+  /** Include the document.referrer: 'https://example.com/page-with-referring-link'
+   * Defaults to 'true' */
+  referrer?: boolean;
+
+  /** Include the full url.
+   * 'https://docs.honeycomb.io/working-with-your-data/overview/#view-events?page=2'
+   *
+   * Defaults to 'false' */
+  url?: boolean;
+
+  /** Include the search params: '?page=2'
+   * Defaults to 'false' */
+  search?: boolean;
+};

--- a/test/entry-page-resource.test.ts
+++ b/test/entry-page-resource.test.ts
@@ -13,19 +13,35 @@ test('it should return a Resource', () => {
   expect(resource).toBeInstanceOf(Resource);
 });
 
-test('it should have location attributes', () => {
+test('when called without a custom config, the resource should include default attributes', () => {
   jest
     .spyOn(document, 'referrer', 'get')
     .mockReturnValue('http://fan-site.com');
 
   const resource = configureEntryPageResource();
   expect(resource.attributes).toEqual({
-    'entry_page.url':
-      'http://something-something.com/some-page?search_params=yes&hello=hi#the-hash',
     'entry_page.path': '/some-page',
-    'entry_page.search': '?search_params=yes&hello=hi',
     'entry_page.hash': '#the-hash',
     'entry_page.hostname': 'something-something.com',
     'entry_page.referrer': 'http://fan-site.com',
+  });
+});
+
+test('when called with false, it should return an emtpy resource', () => {
+  const resource = configureEntryPageResource(false);
+
+  expect(resource.attributes).toEqual({});
+});
+
+test('a custom config overrides the default attributes', () => {
+  jest.spyOn(document, 'referrer', 'get').mockReturnValue('');
+  const resource = configureEntryPageResource({ path: false, url: true });
+
+  expect(resource.attributes).toEqual({
+    'entry_page.url':
+      'http://something-something.com/some-page?search_params=yes&hello=hi#the-hash',
+    'entry_page.hash': '#the-hash',
+    'entry_page.hostname': 'something-something.com',
+    'entry_page.referrer': '',
   });
 });

--- a/test/honeycomb-otel-sdk.test.ts
+++ b/test/honeycomb-otel-sdk.test.ts
@@ -1,7 +1,12 @@
+/**
+ * @jest-environment-options {"url": "http://something-something.com/some-page"}
+ */
+
 import { HoneycombWebSDK } from '../src/honeycomb-otel-sdk';
 import { Resource } from '@opentelemetry/resources';
 import { WebSDK } from '../src/base-otel-sdk';
 import { VERSION } from '../src/version';
+import { HoneycombOptions } from '../src/types';
 
 test('it should extend the OTel WebSDK', () => {
   const honeycomb = new HoneycombWebSDK();
@@ -24,4 +29,40 @@ test('it should merge resources from the configuration', () => {
   expect(attributes['honeycomb.distro.version']).toEqual(VERSION);
   expect(attributes['honeycomb.distro.runtime_version']).toEqual('browser');
   expect(attributes.myTestAttr).toEqual('my-test-attr');
+});
+
+describe('entry page configuration', () => {
+  test('includes entry page attributes by default', () => {
+    const honeycomb = new HoneycombWebSDK();
+    const attributes = honeycomb.getResourceAttributes();
+    expect(attributes['entry_page.path']).toEqual('/some-page');
+  });
+
+  test('does not include entry page attributes when `config.entryPageAttributes` is false', () => {
+    const config: HoneycombOptions = {
+      entryPageAttributes: false,
+    };
+
+    const honeycomb = new HoneycombWebSDK(config);
+
+    const attributes = honeycomb.getResourceAttributes();
+    expect(attributes['entry_page.path']).toBeUndefined();
+  });
+
+  test('it respects custom config options', () => {
+    const config: HoneycombOptions = {
+      entryPageAttributes: {
+        url: true,
+        path: false,
+      },
+    };
+
+    const honeycomb = new HoneycombWebSDK(config);
+
+    const attributes = honeycomb.getResourceAttributes();
+    expect(attributes['entry_page.url']).toEqual(
+      'http://something-something.com/some-page',
+    );
+    expect(attributes['entry_page.path']).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #37 

## Short description of the changes
Adds `entryPageAttribute` config option: either opt out entirely ( entryPageAttributes: false), or pass in a custom config for fine-grained control.

Defaults to _not_ including any field with search params (`search`, `url`)


