### PR TITLE
feat: add BaggageSpanProcessor

### DIFF
--- a/src/baggage-span-processor.ts
+++ b/src/baggage-span-processor.ts
@@ -1,0 +1,43 @@
+import { Context, propagation, Span } from '@opentelemetry/api';
+import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
+
+/**
+ * A {@link SpanProcessor} that reads entries stored in {@link Baggage}
+ * from the parent context and adds the baggage entries' keys and values
+ * to the span as attributes on span start.
+ *
+ * Keys and values added to Baggage will appear on subsequent child
+ * spans for a trace within this service *and* be propagated to external
+ * services in accordance with any configured propagation formats
+ * configured. If the external services also have a Baggage span
+ * processor, the keys and values will appear in those child spans as
+ * well.
+ *
+ * ⚠ Warning ⚠️
+ *
+ * Do not put sensitive information in Baggage.
+ *
+ * To repeat: a consequence of adding data to Baggage is that the keys and
+ * values will appear in all outgoing HTTP headers from the application.
+ */
+export class BaggageSpanProcessor implements SpanProcessor {
+  constructor() {}
+
+  onStart(span: Span, parentContext: Context): void {
+    (propagation.getBaggage(parentContext)?.getAllEntries() ?? []).forEach(
+      (entry) => {
+        span.setAttribute(entry[0], entry[1].value);
+      },
+    );
+  }
+
+  onEnd() {}
+
+  forceFlush() {
+    return Promise.resolve();
+  }
+
+  shutdown() {
+    return Promise.resolve();
+  }
+}

--- a/src/baggage-span-processor.ts
+++ b/src/baggage-span-processor.ts
@@ -1,4 +1,4 @@
-import { Context, propagation, Span } from '@opentelemetry/api';
+import { Context, diag, propagation, Span } from '@opentelemetry/api';
 import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 
 /**
@@ -27,6 +27,9 @@ export class BaggageSpanProcessor implements SpanProcessor {
     (propagation.getBaggage(parentContext)?.getAllEntries() ?? []).forEach(
       (entry) => {
         span.setAttribute(entry[0], entry[1].value);
+        diag.debug(
+          `@honeycombio/opentelemetry-web: 🚨 Baggage in all outgoing headers: ${entry[0]}=${entry[1].value} `,
+        );
       },
     );
   }

--- a/src/span-processor-builder.ts
+++ b/src/span-processor-builder.ts
@@ -1,4 +1,5 @@
 import { HoneycombOptions } from './types';
+import { BaggageSpanProcessor } from './baggage-span-processor';
 import { BrowserAttributesSpanProcessor } from './browser-attributes-span-processor';
 import {
   BatchSpanProcessor,
@@ -18,11 +19,14 @@ import { configureHoneycombHttpJsonTraceExporter } from './http-json-trace-expor
 export const configureSpanProcessors = (options?: HoneycombOptions) => {
   const honeycombSpanProcessor = new CompositeSpanProcessor();
 
-  // We have to configure the exporter here becuase the way the base SDK is setup
+  // We have to configure the exporter here because the way the base SDK is setup
   // does not allow having both a `spanProcessor` and `traceExporter` configured.
   honeycombSpanProcessor.addProcessor(
     new BatchSpanProcessor(configureHoneycombHttpJsonTraceExporter(options)),
   );
+
+  // we always want to add the baggage span processor
+  honeycombSpanProcessor.addProcessor(new BaggageSpanProcessor());
 
   // we always want to add the browser attrs span processor
   honeycombSpanProcessor.addProcessor(new BrowserAttributesSpanProcessor());

--- a/test/baggage-span-processor.test.ts
+++ b/test/baggage-span-processor.test.ts
@@ -1,0 +1,45 @@
+import { BaggageSpanProcessor } from '../src/baggage-span-processor';
+import {
+  propagation,
+  ROOT_CONTEXT,
+  SpanKind,
+  TraceFlags,
+} from '@opentelemetry/api';
+import { BasicTracerProvider, Span } from '@opentelemetry/sdk-trace-base';
+
+describe('BaggageSpanProcessor', () => {
+  const baggageProcessor = new BaggageSpanProcessor();
+
+  const bag = propagation.createBaggage({
+    brand: { value: 'samsonite' },
+  });
+
+  const expectedAttrs = {
+    brand: 'samsonite',
+  };
+
+  let span: Span;
+
+  beforeEach(() => {
+    span = new Span(
+      new BasicTracerProvider().getTracer('baggage-testing'),
+      ROOT_CONTEXT,
+      'Edward W. Span',
+      {
+        traceId: 'e4cda95b652f4a1592b449d5929fda1b',
+        spanId: '7e0c63257de34c92',
+        traceFlags: TraceFlags.SAMPLED,
+      },
+      SpanKind.SERVER,
+    );
+  });
+
+  test('onStart adds current Baggage entries to a span as attributes', () => {
+    expect(span.attributes).toEqual({});
+    const ctx = propagation.setBaggage(ROOT_CONTEXT, bag);
+
+    baggageProcessor.onStart(span, ctx);
+
+    expect(span.attributes).toEqual(expectedAttrs);
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #66 

## Short description of the changes

- Add BaggageSpanProcessor, and configure it in the span processor builder
- Add and update tests to confirm baggage gets added as span attributes
- Add debug log for entries in baggage

## How to verify that this has the expected result

In the example app, add something to baggage and see it show up as an attribute on a span created from parent context:

```js
  const tracer = trace.getTracer('example-tracer');
  // new context based on current, with key/values added to baggage
  const ctx = propagation.setBaggage(
    context.active(),
    propagation.createBaggage({
      for_the_spans: { value: 'important value' },
    }),
  );
  // starting a new span on the tracer using the saved context
  context.with(ctx, () => {
    tracer.startActiveSpan('heygirl', (span) => {
      // do work here
      span.end();
    })
  })
```

![baggage is span attribute](https://github.com/honeycombio/honeycomb-opentelemetry-web/assets/29520003/8a29d739-710a-439c-8394-b8cffa68c39b)

or nest even further to get on downstream spans as well

```js
  const tracer = trace.getTracer('example-tracer');
  // new context based on current, with key/values added to baggage
  const ctx = propagation.setBaggage(
    context.active(),
    propagation.createBaggage({
      for_the_spans: { value: 'important value' },
    }),
  );
  // starting a new span on the tracer using the saved context
  context.with(ctx, () => {
    tracer.startActiveSpan('heygirl', (span) => {
      // do work here
      context.with(trace.setSpan(context.active(), span), () => {
        tracer.startActiveSpan('heygirl2', (childspan) => {
          // do work here
          childspan.end();
        });
        span.end();
      })
    })
  });
```

![image](https://github.com/honeycombio/honeycomb-opentelemetry-web/assets/29520003/9ff3e930-3b26-40c5-865d-88888b9142dc)
