### PR TITLE
docs: describe web-vitals instrumentation config options

### DIFF
--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -1,0 +1,109 @@
+# Web Vitals
+
+By default, Honeycomb includes events for all web vitals except [first-input-delay](https://web.dev/articles/fid). First-input-delay is set to be replaced by interaction-to-next-paint as a core web vital in March 2024.
+
+## Customization of event attributes
+
+For fine-tuned event processing, pass in a custom callback functions for each of the web-vitals:
+
+```js
+
+const sdk = new HoneycombWebSDK({
+  webVitals: {
+    onCLS: (clsWithAttribution) => {//custom event processor },
+  }
+});
+
+```
+
+Supported fields:
+
+```ts
+onCLS?: CLSReportCallbackWithAttribution;
+onFCP?: FCPReportCallbackWithAttribution;
+onFID?: FIDReportCallbackWithAttribution;
+onINP?: INPReportCallbackWithAttribution;
+onLCP?: LCPReportCallbackWithAttribution;
+onTTFB?: TTFBReportCallbackWithAttribution;
+
+```
+
+The callbacks are passed their respective metric with attribution. [web-vitals docs](https://github.com/GoogleChrome/web-vitals?tab=readme-ov-file#metricwithattribution)
+
+**Note**: passing in a custom callback will _replace_ the default attributes provided by this package, not augment.
+
+## Additional Configuration
+
+### Using custom data attribute to identify elements
+
+Sometimes the element selector (used by LCP, INP & CLS events) is not very human-readable (or changes frequently) & makes it difficult to figure out the actual culprit. Pass in a custom data selector & hny will use that identifier instead for the `lcp.element`, `cls.element` & `inp.element` attributes.
+
+```js
+const sdk = new HoneycombWebSDK({
+  serviceName: 'my-app',
+  webVitals: {
+    elementDataAttribute: 'human-id',
+  },
+});
+```
+
+```html
+<input type="color" class="css-1rjml27" data-human-id="favorite-color-picker" />
+```
+
+Example INP event:
+
+```js
+{
+  "web_vital.name: "inp",
+  "inp.element": "favorite-color-picker",
+  // other fields
+}
+```
+
+### Including the metric value in `web_vital.value` attribute
+
+By default, each metric value is namespaced under the metric name, `lcp.value` | `cls.value` | `inp.value`, etc. Chose to include the value in `web_vital.value` attribute:
+
+```js
+const sdk = new HoneycombWebSDK({
+  serviceName: 'my-app',
+  webVitals: {
+    includeValueInTopLevelNamespace: true,
+  },
+});
+```
+
+## Disable web vitals reporting
+
+To disable collection of web vitals, set `webVitals` to false in the config
+
+```js
+const sdk = new HoneycombWebSDK({
+  serviceName: 'my-app',
+  webVitals: false,
+});
+```
+
+## Config Options
+
+```ts
+interface WebVitalsConfig {
+  elementDataAttribute?: string;
+  reportOptions?: {
+    reportAllChanges?: boolean;
+    durationThreshold?: number;
+  };
+  onCLS?: CLSReportCallbackWithAttribution;
+  onFCP?: FCPReportCallbackWithAttribution;
+  onFID?: FIDReportCallbackWithAttribution;
+  onINP?: INPReportCallbackWithAttribution;
+  onLCP?: LCPReportCallbackWithAttribution;
+  onTTFB?: TTFBReportCallbackWithAttribution;
+
+  /** Whether or not the metric's value should be sent as
+   * `web_vital.value` as well as `[metricName].value`, ie `lcp.value`.
+   * Defaults to false */
+  includeValueInTopLevelNamespace?: boolean;
+}
+```

--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -9,7 +9,7 @@ For fine-tuned event processing, pass in a custom callback functions for each of
 ```js
 
 const sdk = new HoneycombWebSDK({
-  webVitals: {
+  webVitalsInstrumentation: {
     onCLS: (clsWithAttribution) => {//custom event processor },
   }
 });
@@ -41,7 +41,7 @@ Sometimes the element selector (used by LCP, INP & CLS events) is not very human
 ```js
 const sdk = new HoneycombWebSDK({
   serviceName: 'my-app',
-  webVitals: {
+  webVitalsInstrumentation: {
     elementDataAttribute: 'human-id',
   },
 });
@@ -68,7 +68,7 @@ By default, each metric value is namespaced under the metric name, `lcp.value` |
 ```js
 const sdk = new HoneycombWebSDK({
   serviceName: 'my-app',
-  webVitals: {
+  webVitalsInstrumentation: {
     includeValueInTopLevelNamespace: true,
   },
 });
@@ -76,12 +76,12 @@ const sdk = new HoneycombWebSDK({
 
 ## Disable web vitals reporting
 
-To disable collection of web vitals, set `webVitals` to false in the config
+To disable collection of web vitals, set `webVitalsInstrumentation` to false in the config
 
 ```js
 const sdk = new HoneycombWebSDK({
   serviceName: 'my-app',
-  webVitals: false,
+  webVitalsInstrumentation: false,
 });
 ```
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,7 +119,7 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
    */
   entryPageAttributes?: false | EntryPageConfig;
 
-  webVitals?: false | WebVitalsConfig;
+  webVitalsInstrumentation?: false | WebVitalsConfig;
 }
 
 interface WebVitalsConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,22 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
    * ```
    */
   entryPageAttributes?: false | EntryPageConfig;
+
+  webVitals?: false | WebVitalsConfig;
+}
+
+interface WebVitalsConfig {
+  elementDataAttribute?: string;
+  reportOptions?: {
+    reportAllChanges?: boolean;
+    durationThreshold?: number;
+  };
+  // onCLS?: CLSReportCallbackWithAttribution;
+  // onFCP?: FCPReportCallbackWithAttribution;
+  // onFID?: FIDReportCallbackWithAttribution;
+  // onINP?: INPReportCallbackWithAttribution;
+  // onLCP?: LCPReportCallbackWithAttribution;
+  // onTTFB?: TTFBReportCallbackWithAttribution;
 }
 
 /* Configure which fields to include in the `entry_page` resource attributes. By default,


### PR DESCRIPTION
[View Formatted Readme](https://github.com/honeycombio/honeycomb-opentelemetry-web/blob/ahr/vitals-conifg-readme/docs/web-vitals.md)
Proposes a configuration set-up for web-vitals, for discussion & alignment prior to writing the actual implementation code

(note: this was originally included as part of #61; pulled out into its own PR)