### PR TITLE
feat: add localVisualizations for link to Honeycomb trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,14 @@ Pass these options to the HoneycombWebSDK:
 | --------------------- | ------------------------------------------------ | ------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | apiKey            | required[*](#send-to-an-opentelemetry-collector) | string  |                         | [Honeycomb API Key](https://docs.honeycomb.io/working-with-your-data/settings/api-keys/) for sending traces directly to Honeycomb.                                         |
 | serviceName         | optional                                         | string  | unknown_service         | The name of this browser application. Your telemetry will go to a Honeycomb dataset with this name.                                                                       |
-| localVisualizations** | optional                                         | boolean | false                   | For each trace created, print a link to the console so that you can find it in Honeycomb. Super useful in development! Do not use in production.                          |
-| sampleRate**            | optional                                         | number  | 1                       | If you want to send a random fraction of traces, then make this a whole number greater than 1. Only 1 in `sampleRate` traces will be sent, and the rest never be created. |
+| localVisualizations | optional                                         | boolean | false                   | For each trace created, print a link to the console so that you can find it in Honeycomb. Super useful in development! Do not use in production.                          |
+| sampleRate            | optional                                         | number  | 1                       | If you want to send a random fraction of traces, then make this a whole number greater than 1. Only 1 in `sampleRate` traces will be sent, and the rest never be created. |
 | tracesEndpoint        | optional                                         | string  | `${endpoint}/v1/traces` | Populate this to send traces to a route other than /v1/traces.                                                                                                             |
 | debug                 | optional                                         | boolean | false                   | Enable additional logging.                                                                                                                                                 |
 | dataset               | optional                                         | string  |                         | Populate this only if your Honeycomb environment is still [Classic](https://docs.honeycomb.io/honeycomb-classic/#am-i-using-honeycomb-classic).                                   |
-| skipOptionsValidation** | optional                                         | boolean | false                   | Do not require any fields.[*](#send-to-an-opentelemetry-collector) Use with OpenTelemetry Collector.                                                                                                       |
+| skipOptionsValidation | optional                                         | boolean | false                   | Do not require any fields.[*](#send-to-an-opentelemetry-collector) Use with OpenTelemetry Collector.                                                                                                       |
 
 `*` Note: the `apiKey` field is required because this SDK really wants to help you send data directly to Honeycomb.
-
-`**` Note: these config options are planned but not implemented yet, they will be available as part of the beta release.
 
 ### Send to an OpenTelemetry Collector
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@opentelemetry/semantic-conventions": "~1.21.0",
         "@typescript-eslint/eslint-plugin": "^6.20.0",
         "@typescript-eslint/parser": "^6.20.0",
+        "axios": "^1.6.7",
         "eslint-config-prettier": "^9.1.0",
         "prettier": "^3.2.4"
       },
@@ -2294,8 +2295,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2332,6 +2332,34 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2834,7 +2862,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3125,7 +3152,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3918,6 +3944,25 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "peer": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -5966,7 +6011,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5975,7 +6019,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9583,8 +9626,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -9609,6 +9651,33 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "requires": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "proxy-from-env": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        }
+      }
     },
     "babel-jest": {
       "version": "29.7.0",
@@ -9955,7 +10024,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -10182,8 +10250,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -10792,6 +10859,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "peer": true
+    },
+    "follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -12288,14 +12360,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@opentelemetry/semantic-conventions": "~1.21.0",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
+    "axios": "^1.6.7",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.2.4"
   }

--- a/src/composite-exporter.ts
+++ b/src/composite-exporter.ts
@@ -1,0 +1,43 @@
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
+
+/**
+ * Builds and returns a new {@link SpanExporter} that wraps the provided array
+ * of {@link SpanExporter}s
+ *
+ * @param exporters the exporters to wrap with the composite exporter
+ * @returns the configured {@link SpanExporter} instance
+ */
+export function configureCompositeExporter(
+  exporters: SpanExporter[],
+): SpanExporter {
+  return new CompositeSpanExporter(exporters);
+}
+
+/**
+ * A custom SpanExporter that wraps a number of other exporters and calls export and shutdown
+ * for each.
+ */
+class CompositeSpanExporter implements SpanExporter {
+  private _exporters: SpanExporter[];
+
+  constructor(exporters: SpanExporter[]) {
+    this._exporters = exporters;
+  }
+
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void,
+  ): void {
+    this._exporters.forEach((exporter) =>
+      exporter.export(spans, resultCallback),
+    );
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+
+  async shutdown(): Promise<void> {
+    const results: Promise<void>[] = [];
+    this._exporters.forEach((exporter) => results.push(exporter.shutdown()));
+    await Promise.all(results);
+  }
+}

--- a/src/console-trace-link-exporter.ts
+++ b/src/console-trace-link-exporter.ts
@@ -1,7 +1,11 @@
 import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { HoneycombOptions } from './types';
-import { getTracesApiKey, isClassic } from './util';
+import {
+  createHoneycombSDKLogMessage,
+  getTracesApiKey,
+  isClassic,
+} from './util';
 import {
   FAILED_AUTH_FOR_LOCAL_VISUALIZATIONS,
   MISSING_FIELDS_FOR_LOCAL_VISUALIZATIONS,
@@ -72,7 +76,9 @@ class ConsoleTraceLinkExporter implements SpanExporter {
         // only log root spans (ones without a parent span)
         if (!span.parentSpanId) {
           console.log(
-            `Honeycomb link: ${this._traceUrl}=${span.spanContext().traceId}`,
+            createHoneycombSDKLogMessage(
+              `Honeycomb link: ${this._traceUrl}=${span.spanContext().traceId}`,
+            ),
           );
         }
       });

--- a/src/console-trace-link-exporter.ts
+++ b/src/console-trace-link-exporter.ts
@@ -1,0 +1,122 @@
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { HoneycombOptions } from './types';
+import { getTracesApiKey, isClassic } from './util';
+import {
+  FAILED_AUTH_FOR_LOCAL_VISUALIZATIONS,
+  MISSING_FIELDS_FOR_LOCAL_VISUALIZATIONS,
+} from './validate-options';
+import axios from 'axios';
+
+/**
+ * Builds and returns a {@link SpanExporter} that logs Honeycomb URLs for completed traces
+ *
+ * @remark This is not for production use.
+ * @param options The {@link HoneycombOptions} used to configure the exporter
+ * @returns the configured {@link ConsoleTraceLinkExporter} instance
+ */
+export function configureConsoleTraceLinkExporter(
+  options?: HoneycombOptions,
+): SpanExporter {
+  const apiKey = getTracesApiKey(options);
+  return new ConsoleTraceLinkExporter(options?.serviceName, apiKey);
+}
+
+/**
+ * A custom {@link SpanExporter} that logs Honeycomb URLs for completed traces.
+ *
+ * @remark This is not for production use.
+ */
+class ConsoleTraceLinkExporter implements SpanExporter {
+  private _traceUrl = '';
+
+  constructor(serviceName?: string, apikey?: string) {
+    if (!serviceName || !apikey) {
+      console.debug(MISSING_FIELDS_FOR_LOCAL_VISUALIZATIONS);
+      return;
+    }
+
+    const options = {
+      headers: {
+        'x-honeycomb-team': apikey,
+      },
+    };
+    axios.get('https://api.honeycomb.io/1/auth', options).then(
+      (resp) => {
+        if (resp.status === 200) {
+          const respData: AuthResponse = resp.data;
+          if (respData.team?.slug) {
+            this._traceUrl = buildTraceUrl(
+              apikey,
+              serviceName,
+              respData.team?.slug,
+              respData.environment?.slug,
+            );
+          } else {
+            console.log(FAILED_AUTH_FOR_LOCAL_VISUALIZATIONS);
+          }
+        }
+      },
+      () => {
+        console.log(FAILED_AUTH_FOR_LOCAL_VISUALIZATIONS);
+      },
+    );
+  }
+
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void,
+  ): void {
+    if (this._traceUrl) {
+      spans.forEach((span) => {
+        // only log root spans (ones without a parent span)
+        if (!span.parentSpanId) {
+          console.log(
+            `Honeycomb link: ${this._traceUrl}=${span.spanContext().traceId}`,
+          );
+        }
+      });
+    }
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Builds and returns a URL that is used to log when a trace is completed in the {@link ConsoleTraceLinkExporter}.
+ *
+ * @param apikey the Honeycomb API key used to retrieve the Honeycomb team and environment
+ * @param serviceName the Honeycomb service name (or classic dataset) where data is stored
+ * @param team the Honeycomb team
+ * @param environment the Honeycomb environment
+ * @returns
+ */
+export function buildTraceUrl(
+  apikey: string,
+  serviceName: string,
+  team: string,
+  environment?: string,
+): string {
+  let url = `https://ui.honeycomb.io/${team}`;
+  if (!isClassic(apikey) && environment) {
+    url += `/environments/${environment}`;
+  }
+  url += `/datasets/${serviceName}/trace?trace_id`;
+  return url;
+}
+
+interface AuthResponse {
+  environment?: EnvironmentResponse;
+  team?: TeamResponse;
+}
+
+interface EnvironmentResponse {
+  slug?: string;
+}
+
+interface TeamResponse {
+  slug?: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,9 +93,8 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
 
   /** The local visualizations flag enables logging Honeycomb URLs for completed traces. Do not use in production.
    * Defaults to 'false'.
-   * TODO: Not yet implemented
    */
-  // localVisualizations?: boolean;
+  localVisualizations?: boolean;
 
   /** Skip options validation warnings (eg no API key configured). This is useful when the SDK is being
    * used in conjunction with an OpenTelemetry Collector (which will handle the API key and dataset configuration).

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,8 +19,7 @@ export const defaultOptions: HoneycombOptions = {
   debug: false,
   sampleRate: 1,
   skipOptionsValidation: false,
-  // TODO: Not yet implemented
-  // localVisualizations: false,
+  localVisualizations: false,
 };
 
 export const createHoneycombSDKLogMessage = (message: string) =>

--- a/src/validate-options.ts
+++ b/src/validate-options.ts
@@ -23,6 +23,14 @@ export const SKIPPING_OPTIONS_VALIDATION_MSG = createHoneycombSDKLogMessage(
 export const SAMPLER_OVERRIDE_WARNING = createHoneycombSDKLogMessage(
   '🔨 Default deterministic sampler has been overridden. Honeycomb requires a resource attribute called SampleRate to properly show weighted values. Non-deterministic sampleRate could lead to missing spans in Honeycomb. See our docs for more details. https://docs.honeycomb.io/getting-data-in/opentelemetry/node-distro/#sampling-without-the-honeycomb-sdk',
 );
+export const MISSING_FIELDS_FOR_LOCAL_VISUALIZATIONS =
+  createHoneycombSDKLogMessage(
+    '🔕 Disabling local visualizations - must have both service name and API key configured.',
+  );
+export const FAILED_AUTH_FOR_LOCAL_VISUALIZATIONS =
+  createHoneycombSDKLogMessage(
+    '🔕 Failed to get proper auth response from Honeycomb. No local visualization available.',
+  );
 
 export const validateOptionsWarnings = (options?: HoneycombOptions) => {
   if (options?.skipOptionsValidation) {

--- a/test/console-trace-link-exporter.test.ts
+++ b/test/console-trace-link-exporter.test.ts
@@ -1,0 +1,30 @@
+import { buildTraceUrl } from '../src/console-trace-link-exporter';
+
+const apikey = '000000000000000000000000';
+const classicApikey = '00000000000000000000000000000000';
+
+describe('buildTraceUrl', () => {
+  it('builds environment trace URL', () => {
+    const url = buildTraceUrl(
+      apikey,
+      'my-service',
+      'my-team',
+      'my-environment',
+    );
+    expect(url).toBe(
+      'https://ui.honeycomb.io/my-team/environments/my-environment/datasets/my-service/trace?trace_id',
+    );
+  });
+
+  it('builds classic trace URL', () => {
+    const url = buildTraceUrl(
+      classicApikey,
+      'my-service',
+      'my-team',
+      'my-environment',
+    );
+    expect(url).toBe(
+      'https://ui.honeycomb.io/my-team/datasets/my-service/trace?trace_id',
+    );
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #69 

## Short description of the changes

- Add `ConsoleTraceLinkExporter` that logs in the console a direct link to a trace in Honeycomb
- Add `CompositeExporter` to allow for configuring multiple exporters, which is necessary for using both our regular OTLP exporter (to Honeycomb) and this console exporter
- Update the span processor builder to allow for both the `ConsoleTraceLinkExporter` and a user-provided exporter, such as a regular `ConsoleSpanExporter`
- Update README for this option and others recently added

## How to verify that this has the expected result

Update example app to include `localVisualizations: true` and click the link in the console to be brought directly to a trace in Honeycomb
![honeycomb link to trace](https://github.com/honeycombio/honeycomb-opentelemetry-web/assets/29520003/aaf98a70-e56e-4e55-9b0c-96979849b920)


