### PR TITLE
feat: initial web vitals instrumentation 

### DIFF
--- a/examples/hello-world-web/index.js
+++ b/examples/hello-world-web/index.js
@@ -1,4 +1,7 @@
-import { HoneycombWebSDK } from '@honeycombio/opentelemetry-web';
+import {
+  HoneycombWebSDK,
+  WebVitalsInstrumentation,
+} from '@honeycombio/opentelemetry-web';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 
 const main = () => {
@@ -9,7 +12,10 @@ const main = () => {
     endpoint: 'http://localhost:4318', // send to local collector
     serviceName: 'web-distro',
     debug: true,
-    instrumentations: [getWebAutoInstrumentations()], // add auto-instrumentation
+    instrumentations: [
+      getWebAutoInstrumentations(),
+      new WebVitalsInstrumentation(),
+    ], // add auto-instrumentation
   });
   sdk.start();
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "@typescript-eslint/eslint-plugin": "^6.20.0",
         "@typescript-eslint/parser": "^6.20.0",
         "eslint-config-prettier": "^9.1.0",
-        "prettier": "^3.2.4"
+        "prettier": "^3.2.4",
+        "web-vitals": "^3.5.2"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",
@@ -7666,6 +7667,11 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
+      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg=="
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -13493,6 +13499,11 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "web-vitals": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
+      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg=="
     },
     "webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
     "eslint-config-prettier": "^9.1.0",
-    "prettier": "^3.2.4"
+    "prettier": "^3.2.4",
+    "web-vitals": "^3.5.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './base-otel-sdk';
 export * from './honeycomb-otel-sdk';
+export * from './web-vitals-autoinstrumentation';

--- a/src/web-vitals-autoinstrumentation.ts
+++ b/src/web-vitals-autoinstrumentation.ts
@@ -24,9 +24,19 @@ import {
   InstrumentationConfig,
 } from '@opentelemetry/instrumentation';
 
+export interface WebVitalsInstrumentationConfig extends InstrumentationConfig {
+  vitalsToTrack: Array<Metric['name']>;
+}
+
 export class WebVitalsInstrumentation extends InstrumentationBase {
-  constructor(config: InstrumentationConfig) {
+  readonly vitalsToTrack: Array<Metric['name']>;
+  constructor(
+    config: WebVitalsInstrumentationConfig = {
+      vitalsToTrack: ['CLS', 'LCP', 'INP'],
+    },
+  ) {
     super('@honeycombio/instrumentation-web-vitals', '0.0.1', config);
+    this.vitalsToTrack = config.vitalsToTrack;
   }
 
   init() {}
@@ -47,7 +57,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     };
   }
 
-  private onReportCLS(cls: CLSMetricWithAttribution) {
+  private onReportCLS = (cls: CLSMetricWithAttribution) => {
     const { name, attribution } = cls;
     const {
       largestShiftTarget,
@@ -70,9 +80,9 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     });
 
     span.end();
-  }
+  };
 
-  private onReportLCP(lcp: LCPMetricWithAttribution) {
+  private onReportLCP = (lcp: LCPMetricWithAttribution) => {
     const { name, attribution } = lcp;
     const {
       element,
@@ -96,9 +106,9 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     });
 
     span.end();
-  }
+  };
 
-  private onReportINP(inp: INPMetricWithAttribution) {
+  private onReportINP = (inp: INPMetricWithAttribution) => {
     const { name, attribution } = inp;
     const { eventTarget, eventType, loadState }: INPAttribution = attribution;
     const attrPrefix = this.getAttrPrefix(name);
@@ -113,9 +123,9 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     });
 
     span.end();
-  }
+  };
 
-  private onReportFCP(fcp: FCPMetricWithAttribution) {
+  private onReportFCP = (fcp: FCPMetricWithAttribution) => {
     const { name, attribution } = fcp;
     const { timeToFirstByte, firstByteToFCP, loadState }: FCPAttribution =
       attribution;
@@ -131,9 +141,9 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     });
 
     span.end();
-  }
+  };
 
-  private onReportFID(fid: FIDMetricWithAttribution) {
+  private onReportFID = (fid: FIDMetricWithAttribution) => {
     const { name, attribution } = fid;
     const { eventTarget, eventType, loadState }: FIDAttribution = attribution;
     const attrPrefix = this.getAttrPrefix(name);
@@ -148,9 +158,9 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     });
 
     span.end();
-  }
+  };
 
-  private onReportTTFB(ttfb: TTFBMetricWithAttribution) {
+  private onReportTTFB = (ttfb: TTFBMetricWithAttribution) => {
     const { name, attribution } = ttfb;
     const {
       waitingTime,
@@ -170,29 +180,47 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     });
 
     span.end();
-  }
+  };
 
   enable(): void {
     if (!this._config.enabled) {
       return;
     }
-    onCLS((vital) => {
-      this.onReportCLS(vital);
-    });
-    onFID((vital) => {
-      this.onReportFID(vital);
-    });
-    onLCP((vital) => {
-      this.onReportLCP(vital);
-    });
-    onINP((vital) => {
-      this.onReportINP(vital);
-    });
-    onTTFB((vital) => {
-      this.onReportTTFB(vital);
-    });
-    onFCP((vital) => {
-      this.onReportFCP(vital);
-    });
+
+    if (this.vitalsToTrack.includes('CLS')) {
+      onCLS((vital) => {
+        this.onReportCLS(vital);
+      });
+    }
+
+    if (this.vitalsToTrack.includes('LCP')) {
+      onLCP((vital) => {
+        this.onReportLCP(vital);
+      });
+    }
+
+    if (this.vitalsToTrack.includes('INP')) {
+      onINP((vital) => {
+        this.onReportINP(vital);
+      });
+    }
+
+    if (this.vitalsToTrack.includes('FID')) {
+      onFID((vital) => {
+        this.onReportFID(vital);
+      });
+    }
+
+    if (this.vitalsToTrack.includes('TTFB')) {
+      onTTFB((vital) => {
+        this.onReportTTFB(vital);
+      });
+    }
+
+    if (this.vitalsToTrack.includes('FCP')) {
+      onFCP((vital) => {
+        this.onReportFCP(vital);
+      });
+    }
   }
 }

--- a/src/web-vitals-autoinstrumentation.ts
+++ b/src/web-vitals-autoinstrumentation.ts
@@ -1,0 +1,136 @@
+import {
+  CLSAttribution,
+  CLSMetricWithAttribution,
+  FCPAttribution,
+  FCPMetricWithAttribution,
+  FIDAttribution,
+  FIDMetricWithAttribution,
+  INPAttribution,
+  INPMetricWithAttribution,
+  LCPAttribution,
+  LCPMetricWithAttribution,
+  onCLS,
+  onFID,
+  onINP,
+  onLCP,
+  TTFBAttribution,
+  TTFBMetricWithAttribution,
+} from 'web-vitals/attribution';
+import { InstrumentationBase } from '@opentelemetry/instrumentation';
+import { trace } from '@opentelemetry/api';
+
+type WebVitalWithAttribution =
+  | LCPMetricWithAttribution
+  | CLSMetricWithAttribution
+  | FIDMetricWithAttribution
+  | INPMetricWithAttribution
+  | FCPMetricWithAttribution
+  | TTFBMetricWithAttribution;
+
+export class WebVitalsInstrumentation extends InstrumentationBase {
+  init() {}
+
+  private onReport(vital: WebVitalWithAttribution) {
+    const SPAN_ATTRIBUTE_PREFIX = 'web_vital';
+    const { name, id, delta, rating, value, navigationType } = vital;
+    const span = trace
+      .getTracer('@honeycombio/instrumentation-web-vitals')
+      .startSpan(name);
+
+    span.setAttributes({
+      [`${SPAN_ATTRIBUTE_PREFIX}.name`]: name,
+      [`${SPAN_ATTRIBUTE_PREFIX}.id`]: id,
+      [`${SPAN_ATTRIBUTE_PREFIX}.delta`]: delta,
+      [`${SPAN_ATTRIBUTE_PREFIX}.value`]: value,
+      [`${SPAN_ATTRIBUTE_PREFIX}.rating`]: rating,
+      [`${SPAN_ATTRIBUTE_PREFIX}.navigation_type`]: navigationType,
+    });
+
+    switch (name) {
+      case 'CLS': {
+        const {
+          largestShiftTarget,
+          largestShiftTime,
+          largestShiftValue,
+          loadState,
+          largestShiftEntry,
+        }: CLSAttribution = vital.attribution;
+        span.setAttributes({
+          'cls.largest_shift_target': largestShiftTarget,
+          'cls.element': largestShiftTarget,
+          'cls.largest_shift_time': largestShiftTime,
+          'cls.largest_shift_value': largestShiftValue,
+          'cls.load_state': loadState,
+          'cls.had_recent_input': largestShiftEntry?.hadRecentInput,
+        });
+        break;
+      }
+      case 'LCP': {
+        const {
+          element,
+          url,
+          timeToFirstByte,
+          resourceLoadDelay,
+          resourceLoadTime,
+          elementRenderDelay,
+        }: LCPAttribution = vital.attribution;
+        span.setAttributes({
+          'lcp.element': element,
+          'lcp.url': url,
+          'lcp.time_to_first_byte': timeToFirstByte,
+          'lcp.resource_load_delay': resourceLoadDelay,
+          'lcp.resource_load_time': resourceLoadTime,
+          'lcp.element_render_delay': elementRenderDelay,
+        });
+        break;
+      }
+      case 'INP': {
+        const { eventTarget, eventType, loadState }: INPAttribution =
+          vital.attribution;
+
+        span.setAttributes({
+          'inp.element': eventTarget,
+          'inp.event_type': eventType,
+          'inp.load_state': loadState,
+        });
+        break;
+      }
+      case 'FCP': {
+        const { timeToFirstByte, firstByteToFCP, loadState }: FCPAttribution =
+          vital.attribution;
+        span.setAttributes({
+          'fcp.time_to_first_byte': timeToFirstByte,
+          'fcp.time_since_first_byte': firstByteToFCP,
+          'fcp.load_state': loadState,
+        });
+        break;
+      }
+      case 'TTFB': {
+        const {
+          waitingTime,
+          dnsTime,
+          connectionTime,
+          requestTime,
+        }: TTFBAttribution = vital.attribution;
+        span.setAttributes({
+          'ttfb.waiting_time': waitingTime,
+          'ttfb.dns_time': dnsTime,
+          'ttfb.connection_time': connectionTime,
+          'ttfb.request_time': requestTime,
+        });
+        break;
+      }
+      case 'FID': {
+        const { eventTarget, eventType, loadState }: FIDAttribution =
+          vital.attribution;
+        span.setAttributes({
+          'fid.element': eventTarget,
+          'fid.event_type': eventType,
+          'fid.load_state': loadState,
+        });
+      }
+    }
+  }
+
+  enable(): void {}
+}

--- a/src/web-vitals-autoinstrumentation.ts
+++ b/src/web-vitals-autoinstrumentation.ts
@@ -19,12 +19,16 @@ import {
   TTFBAttribution,
   TTFBMetricWithAttribution,
 } from 'web-vitals/attribution';
-import { InstrumentationBase } from '@opentelemetry/instrumentation';
+import {
+  InstrumentationBase,
+  InstrumentationConfig,
+} from '@opentelemetry/instrumentation';
 
 export class WebVitalsInstrumentation extends InstrumentationBase {
-  constructor() {
-    super('@honeycombio/instrumentation-web-vitals', '0.0.1');
+  constructor(config: InstrumentationConfig) {
+    super('@honeycombio/instrumentation-web-vitals', '0.0.1', config);
   }
+
   init() {}
 
   private getAttrPrefix(name: string) {
@@ -169,6 +173,9 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
   }
 
   enable(): void {
+    if (!this._config.enabled) {
+      return;
+    }
     onCLS((vital) => {
       this.onReportCLS(vital);
     });

--- a/src/web-vitals-autoinstrumentation.ts
+++ b/src/web-vitals-autoinstrumentation.ts
@@ -9,7 +9,9 @@ import {
   INPMetricWithAttribution,
   LCPAttribution,
   LCPMetricWithAttribution,
+  Metric,
   onCLS,
+  onFCP,
   onFID,
   onINP,
   onLCP,
@@ -19,210 +21,160 @@ import {
 } from 'web-vitals/attribution';
 import { InstrumentationBase } from '@opentelemetry/instrumentation';
 
-type WebVitalWithAttribution =
-  | LCPMetricWithAttribution
-  | CLSMetricWithAttribution
-  | FIDMetricWithAttribution
-  | INPMetricWithAttribution
-  | FCPMetricWithAttribution
-  | TTFBMetricWithAttribution;
-
 export class WebVitalsInstrumentation extends InstrumentationBase {
   constructor() {
     super('@honeycombio/instrumentation-web-vitals', '0.0.1');
   }
   init() {}
 
-  private onReport(vital: WebVitalWithAttribution) {
-    const SPAN_ATTRIBUTE_PREFIX = 'web_vital';
+  private getSharedAttributes(vital: Metric) {
     const { name, id, delta, rating, value, navigationType } = vital;
+    return {
+      [`${name}.id`]: id,
+      [`${name}.delta`]: delta,
+      [`${name}.value`]: value,
+      [`${name}.rating`]: rating,
+      [`${name}.navigation_type`]: navigationType,
+    };
+  }
+
+  private onReportCLS(cls: CLSMetricWithAttribution) {
+    const { name, attribution } = cls;
+    const {
+      largestShiftTarget,
+      largestShiftTime,
+      largestShiftValue,
+      loadState,
+      largestShiftEntry,
+    }: CLSAttribution = attribution;
+
+    const span = this.tracer.startSpan(name);
+    span.setAttributes({
+      ...this.getSharedAttributes(cls),
+      [`${name}.largest_shift_target`]: largestShiftTarget,
+      [`${name}.element`]: largestShiftTarget,
+      [`${name}.largest_shift_time`]: largestShiftTime,
+      [`${name}.largest_shift_value`]: largestShiftValue,
+      [`${name}.load_state`]: loadState,
+      [`${name}.had_recent_input`]: largestShiftEntry?.hadRecentInput,
+    });
+
+    span.end();
+  }
+
+  private onReportLCP(lcp: LCPMetricWithAttribution) {
+    const { name, attribution } = lcp;
+    const {
+      element,
+      url,
+      timeToFirstByte,
+      resourceLoadDelay,
+      resourceLoadTime,
+      elementRenderDelay,
+    }: LCPAttribution = attribution;
+
+    const span = this.tracer.startSpan(name);
+    span.setAttributes({
+      ...this.getSharedAttributes(lcp),
+      [`${name}.element`]: element,
+      [`${name}.url`]: url,
+      [`${name}.time_to_first_byte`]: timeToFirstByte,
+      [`${name}.resource_load_delay`]: resourceLoadDelay,
+      [`${name}.resource_load_time`]: resourceLoadTime,
+      [`${name}.element_render_delay`]: elementRenderDelay,
+    });
+
+    span.end();
+  }
+
+  private onReportINP(inp: INPMetricWithAttribution) {
+    const { name, attribution } = inp;
+    const { eventTarget, eventType, loadState }: INPAttribution = attribution;
+
     const span = this.tracer.startSpan(name);
 
     span.setAttributes({
-      [`${SPAN_ATTRIBUTE_PREFIX}.name`]: name,
-      [`${SPAN_ATTRIBUTE_PREFIX}.id`]: id,
-      [`${SPAN_ATTRIBUTE_PREFIX}.delta`]: delta,
-      [`${SPAN_ATTRIBUTE_PREFIX}.value`]: value,
-      [`${SPAN_ATTRIBUTE_PREFIX}.rating`]: rating,
-      [`${SPAN_ATTRIBUTE_PREFIX}.navigation_type`]: navigationType,
+      ...this.getSharedAttributes(inp),
+      [`${name}.element`]: eventTarget,
+      [`${name}.event_type`]: eventType,
+      [`${name}.load_state`]: loadState,
     });
 
-    switch (name) {
-      case 'CLS': {
-        const {
-          largestShiftTarget,
-          largestShiftTime,
-          largestShiftValue,
-          loadState,
-          largestShiftEntry,
-        }: CLSAttribution = vital.attribution;
-        span.setAttributes({
-          'cls.largest_shift_target': largestShiftTarget,
-          'cls.element': largestShiftTarget,
-          'cls.largest_shift_time': largestShiftTime,
-          'cls.largest_shift_value': largestShiftValue,
-          'cls.load_state': loadState,
-          'cls.had_recent_input': largestShiftEntry?.hadRecentInput,
-        });
-        break;
-      }
-      case 'LCP': {
-        const {
-          element,
-          url,
-          timeToFirstByte,
-          resourceLoadDelay,
-          resourceLoadTime,
-          elementRenderDelay,
-        }: LCPAttribution = vital.attribution;
-        span.setAttributes({
-          'lcp.element': element,
-          'lcp.url': url,
-          'lcp.time_to_first_byte': timeToFirstByte,
-          'lcp.resource_load_delay': resourceLoadDelay,
-          'lcp.resource_load_time': resourceLoadTime,
-          'lcp.element_render_delay': elementRenderDelay,
-        });
-        break;
-      }
-      case 'INP': {
-        const { eventTarget, eventType, loadState }: INPAttribution =
-          vital.attribution;
+    span.end();
+  }
 
-        span.setAttributes({
-          'inp.element': eventTarget,
-          'inp.event_type': eventType,
-          'inp.load_state': loadState,
-        });
-        break;
-      }
-      case 'FCP': {
-        const { timeToFirstByte, firstByteToFCP, loadState }: FCPAttribution =
-          vital.attribution;
-        span.setAttributes({
-          'fcp.time_to_first_byte': timeToFirstByte,
-          'fcp.time_since_first_byte': firstByteToFCP,
-          'fcp.load_state': loadState,
-        });
-        break;
-      }
-      case 'TTFB': {
-        const {
-          waitingTime,
-          dnsTime,
-          connectionTime,
-          requestTime,
-        }: TTFBAttribution = vital.attribution;
-        span.setAttributes({
-          'ttfb.waiting_time': waitingTime,
-          'ttfb.dns_time': dnsTime,
-          'ttfb.connection_time': connectionTime,
-          'ttfb.request_time': requestTime,
-        });
-        break;
-      }
-      case 'FID': {
-        const { eventTarget, eventType, loadState }: FIDAttribution =
-          vital.attribution;
-        span.setAttributes({
-          'fid.element': eventTarget,
-          'fid.event_type': eventType,
-          'fid.load_state': loadState,
-        });
-      }
-    }
+  private onReportFCP(fcp: FCPMetricWithAttribution) {
+    const { name, attribution } = fcp;
+    const { timeToFirstByte, firstByteToFCP, loadState }: FCPAttribution =
+      attribution;
+
+    const span = this.tracer.startSpan(name);
+
+    span.setAttributes({
+      ...this.getSharedAttributes(fcp),
+      [`${name}.time_to_first_byte`]: timeToFirstByte,
+      [`${name}.time_since_first_byte`]: firstByteToFCP,
+      [`${name}.load_state`]: loadState,
+    });
+
+    span.end();
+  }
+
+  private onReportFID(fid: FIDMetricWithAttribution) {
+    const { name, attribution } = fid;
+    const { eventTarget, eventType, loadState }: FIDAttribution = attribution;
+
+    const span = this.tracer.startSpan(name);
+
+    span.setAttributes({
+      ...this.getSharedAttributes(fid),
+      [`${name}.element`]: eventTarget,
+      [`${name}.event_type`]: eventType,
+      [`${name}.load_state`]: loadState,
+    });
+
+    span.end();
+  }
+
+  private onReportTTFB(ttfb: TTFBMetricWithAttribution) {
+    const { name, attribution } = ttfb;
+    const {
+      waitingTime,
+      dnsTime,
+      connectionTime,
+      requestTime,
+    }: TTFBAttribution = attribution;
+
+    const span = this.tracer.startSpan(name);
+
+    span.setAttributes({
+      [`${name}.waiting_time`]: waitingTime,
+      [`${name}.dns_time`]: dnsTime,
+      [`${name}.connection_time`]: connectionTime,
+      [`${name}.request_time`]: requestTime,
+    });
+
+    span.end();
   }
 
   enable(): void {
     onCLS((vital) => {
-      this.onReport(vital);
+      this.onReportCLS(vital);
     });
     onFID((vital) => {
-      this.onReport(vital);
+      this.onReportFID(vital);
     });
     onLCP((vital) => {
-      this.onReport(vital);
+      this.onReportLCP(vital);
     });
     onINP((vital) => {
-      this.onReport(vital);
+      this.onReportINP(vital);
     });
     onTTFB((vital) => {
-      this.onReport(vital);
+      this.onReportTTFB(vital);
+    });
+    onFCP((vital) => {
+      this.onReportFCP(vital);
     });
   }
 }
-
-// export class WebVitalsInstrumentation extends InstrumentationBase {
-//   onReport(metric, parentSpanContext) {
-//     const now = hrTime();
-//     const webVitalsSpan = trace
-//       .getTracer('web-vitals-instrumentation')
-//       .startSpan(metric.name, { startTime: now }, parentSpanContext);
-
-//     webVitalsSpan.setAttributes({
-//       [`web_vital.name`]: metric.name,
-//       [`web_vital.id`]: metric.id,
-//       [`web_vital.navigationType`]: metric.navigationType,
-//       [`web_vital.delta`]: metric.delta,
-//       [`web_vital.rating`]: metric.rating,
-//       [`web_vital.value`]: metric.value,
-//       // can expand these into their own attributes!
-//       [`web_vital.entries`]: JSON.stringify(metric.entries),
-//     });
-//     switch (metric.name) {
-//       case 'LCP':
-//         webVitalsSpan.setAttributes({
-//           'web_vital.lcp.element': metric.attribution.element,
-//         });
-//         break;
-
-//       case 'CLS':
-//         webVitalsSpan.setAttributes({
-//           'web_vital.cls.largestShiftTarget':
-//             metric.attribution.largestShiftTarget,
-//         });
-//         break;
-//       case 'FID':
-//         webVitalsSpan.setAttributes({
-//           'web_vital.fid.eventTarget': metric.attribution.eventTarget,
-//         });
-//         break;
-//       case 'INP':
-//         webVitalsSpan.setAttributes({
-//           'web_vital.inp.eventTarget': metric.attribution.eventTarget,
-//         });
-//         break;
-
-//       default:
-//         break;
-//     }
-//     webVitalsSpan.end();
-//   }
-
-//   enable() {
-//     if (this.enabled) {
-//       return;
-//     }
-//     this.enabled = true;
-
-//     // create a parent span that will have all web vitals spans as children
-//     const parentSpan = trace
-//       .getTracer('web-vitals-instrumentation')
-//       .startSpan('web-vitals');
-//     const ctx = trace.setSpan(context.active(), parentSpan);
-//     parentSpan.end();
-
-//     onFID((metric) => {
-//       this.onReport(metric, ctx);
-//     });
-//     onCLS((metric) => {
-//       this.onReport(metric, ctx);
-//     });
-//     onLCP((metric) => {
-//       this.onReport(metric, ctx);
-//     });
-//     onINP((metric) => {
-//       this.onReport(metric, ctx);
-//     });
-//   }
-// }

--- a/src/web-vitals-autoinstrumentation.ts
+++ b/src/web-vitals-autoinstrumentation.ts
@@ -25,7 +25,7 @@ import {
 } from '@opentelemetry/instrumentation';
 
 export interface WebVitalsInstrumentationConfig extends InstrumentationConfig {
-  vitalsToTrack: Array<Metric['name']>;
+  vitalsToTrack?: Array<Metric['name']>;
 }
 
 export class WebVitalsInstrumentation extends InstrumentationBase {
@@ -33,7 +33,6 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
 
   constructor(
     config: WebVitalsInstrumentationConfig = {
-      vitalsToTrack: ['CLS', 'LCP', 'INP'],
       enabled: true,
     },
   ) {
@@ -50,7 +49,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
       // directly, this instrumentation is a bit of a special case.
       enabled: false,
     });
-    this.vitalsToTrack = config?.vitalsToTrack;
+    this.vitalsToTrack = config?.vitalsToTrack || ['CLS', 'LCP', 'INP'];
 
     if (config.enabled === true) {
       this.enable();
@@ -75,7 +74,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     };
   }
 
-  private onReportCLS = (cls: CLSMetricWithAttribution) => {
+  onReportCLS = (cls: CLSMetricWithAttribution) => {
     const { name, attribution } = cls;
     const {
       largestShiftTarget,
@@ -100,7 +99,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     span.end();
   };
 
-  private onReportLCP = (lcp: LCPMetricWithAttribution) => {
+  onReportLCP = (lcp: LCPMetricWithAttribution) => {
     const { name, attribution } = lcp;
     const {
       element,
@@ -126,7 +125,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     span.end();
   };
 
-  private onReportINP = (inp: INPMetricWithAttribution) => {
+  onReportINP = (inp: INPMetricWithAttribution) => {
     const { name, attribution } = inp;
     const { eventTarget, eventType, loadState }: INPAttribution = attribution;
     const attrPrefix = this.getAttrPrefix(name);
@@ -143,7 +142,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     span.end();
   };
 
-  private onReportFCP = (fcp: FCPMetricWithAttribution) => {
+  onReportFCP = (fcp: FCPMetricWithAttribution) => {
     const { name, attribution } = fcp;
     const { timeToFirstByte, firstByteToFCP, loadState }: FCPAttribution =
       attribution;
@@ -161,7 +160,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     span.end();
   };
 
-  private onReportFID = (fid: FIDMetricWithAttribution) => {
+  onReportFID = (fid: FIDMetricWithAttribution) => {
     const { name, attribution } = fid;
     const { eventTarget, eventType, loadState }: FIDAttribution = attribution;
     const attrPrefix = this.getAttrPrefix(name);
@@ -178,7 +177,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     span.end();
   };
 
-  private onReportTTFB = (ttfb: TTFBMetricWithAttribution) => {
+  onReportTTFB = (ttfb: TTFBMetricWithAttribution) => {
     const { name, attribution } = ttfb;
     const {
       waitingTime,
@@ -191,6 +190,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     const span = this.tracer.startSpan(name);
 
     span.setAttributes({
+      ...this.getSharedAttributes(ttfb),
       [`${attrPrefix}.waiting_time`]: waitingTime,
       [`${attrPrefix}.dns_time`]: dnsTime,
       [`${attrPrefix}.connection_time`]: connectionTime,

--- a/src/web-vitals-autoinstrumentation.ts
+++ b/src/web-vitals-autoinstrumentation.ts
@@ -27,14 +27,19 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
   }
   init() {}
 
+  private getAttrPrefix(name: string) {
+    return name.toLowerCase();
+  }
+
   private getSharedAttributes(vital: Metric) {
     const { name, id, delta, rating, value, navigationType } = vital;
+    const attrPrefix = this.getAttrPrefix(name);
     return {
-      [`${name}.id`]: id,
-      [`${name}.delta`]: delta,
-      [`${name}.value`]: value,
-      [`${name}.rating`]: rating,
-      [`${name}.navigation_type`]: navigationType,
+      [`${attrPrefix}.id`]: id,
+      [`${attrPrefix}.delta`]: delta,
+      [`${attrPrefix}.value`]: value,
+      [`${attrPrefix}.rating`]: rating,
+      [`${attrPrefix}.navigation_type`]: navigationType,
     };
   }
 
@@ -47,16 +52,17 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
       loadState,
       largestShiftEntry,
     }: CLSAttribution = attribution;
+    const attrPrefix = this.getAttrPrefix(name);
 
     const span = this.tracer.startSpan(name);
     span.setAttributes({
       ...this.getSharedAttributes(cls),
-      [`${name}.largest_shift_target`]: largestShiftTarget,
-      [`${name}.element`]: largestShiftTarget,
-      [`${name}.largest_shift_time`]: largestShiftTime,
-      [`${name}.largest_shift_value`]: largestShiftValue,
-      [`${name}.load_state`]: loadState,
-      [`${name}.had_recent_input`]: largestShiftEntry?.hadRecentInput,
+      [`${attrPrefix}.largest_shift_target`]: largestShiftTarget,
+      [`${attrPrefix}.element`]: largestShiftTarget,
+      [`${attrPrefix}.largest_shift_time`]: largestShiftTime,
+      [`${attrPrefix}.largest_shift_value`]: largestShiftValue,
+      [`${attrPrefix}.load_state`]: loadState,
+      [`${attrPrefix}.had_recent_input`]: largestShiftEntry?.hadRecentInput,
     });
 
     span.end();
@@ -72,16 +78,17 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
       resourceLoadTime,
       elementRenderDelay,
     }: LCPAttribution = attribution;
+    const attrPrefix = this.getAttrPrefix(name);
 
     const span = this.tracer.startSpan(name);
     span.setAttributes({
       ...this.getSharedAttributes(lcp),
-      [`${name}.element`]: element,
-      [`${name}.url`]: url,
-      [`${name}.time_to_first_byte`]: timeToFirstByte,
-      [`${name}.resource_load_delay`]: resourceLoadDelay,
-      [`${name}.resource_load_time`]: resourceLoadTime,
-      [`${name}.element_render_delay`]: elementRenderDelay,
+      [`${attrPrefix}.element`]: element,
+      [`${attrPrefix}.url`]: url,
+      [`${attrPrefix}.time_to_first_byte`]: timeToFirstByte,
+      [`${attrPrefix}.resource_load_delay`]: resourceLoadDelay,
+      [`${attrPrefix}.resource_load_time`]: resourceLoadTime,
+      [`${attrPrefix}.element_render_delay`]: elementRenderDelay,
     });
 
     span.end();
@@ -90,14 +97,15 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
   private onReportINP(inp: INPMetricWithAttribution) {
     const { name, attribution } = inp;
     const { eventTarget, eventType, loadState }: INPAttribution = attribution;
+    const attrPrefix = this.getAttrPrefix(name);
 
     const span = this.tracer.startSpan(name);
 
     span.setAttributes({
       ...this.getSharedAttributes(inp),
-      [`${name}.element`]: eventTarget,
-      [`${name}.event_type`]: eventType,
-      [`${name}.load_state`]: loadState,
+      [`${attrPrefix}.element`]: eventTarget,
+      [`${attrPrefix}.event_type`]: eventType,
+      [`${attrPrefix}.load_state`]: loadState,
     });
 
     span.end();
@@ -107,14 +115,15 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     const { name, attribution } = fcp;
     const { timeToFirstByte, firstByteToFCP, loadState }: FCPAttribution =
       attribution;
+    const attrPrefix = this.getAttrPrefix(name);
 
     const span = this.tracer.startSpan(name);
 
     span.setAttributes({
       ...this.getSharedAttributes(fcp),
-      [`${name}.time_to_first_byte`]: timeToFirstByte,
-      [`${name}.time_since_first_byte`]: firstByteToFCP,
-      [`${name}.load_state`]: loadState,
+      [`${attrPrefix}.time_to_first_byte`]: timeToFirstByte,
+      [`${attrPrefix}.time_since_first_byte`]: firstByteToFCP,
+      [`${attrPrefix}.load_state`]: loadState,
     });
 
     span.end();
@@ -123,14 +132,15 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
   private onReportFID(fid: FIDMetricWithAttribution) {
     const { name, attribution } = fid;
     const { eventTarget, eventType, loadState }: FIDAttribution = attribution;
+    const attrPrefix = this.getAttrPrefix(name);
 
     const span = this.tracer.startSpan(name);
 
     span.setAttributes({
       ...this.getSharedAttributes(fid),
-      [`${name}.element`]: eventTarget,
-      [`${name}.event_type`]: eventType,
-      [`${name}.load_state`]: loadState,
+      [`${attrPrefix}.element`]: eventTarget,
+      [`${attrPrefix}.event_type`]: eventType,
+      [`${attrPrefix}.load_state`]: loadState,
     });
 
     span.end();
@@ -144,14 +154,15 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
       connectionTime,
       requestTime,
     }: TTFBAttribution = attribution;
+    const attrPrefix = this.getAttrPrefix(name);
 
     const span = this.tracer.startSpan(name);
 
     span.setAttributes({
-      [`${name}.waiting_time`]: waitingTime,
-      [`${name}.dns_time`]: dnsTime,
-      [`${name}.connection_time`]: connectionTime,
-      [`${name}.request_time`]: requestTime,
+      [`${attrPrefix}.waiting_time`]: waitingTime,
+      [`${attrPrefix}.dns_time`]: dnsTime,
+      [`${attrPrefix}.connection_time`]: connectionTime,
+      [`${attrPrefix}.request_time`]: requestTime,
     });
 
     span.end();

--- a/test/web-vitals-instrumentation.test.ts
+++ b/test/web-vitals-instrumentation.test.ts
@@ -1,0 +1,253 @@
+import { WebVitalsInstrumentation } from '../src/web-vitals-autoinstrumentation';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  ReadableSpan,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+
+describe('Web Vitals Instrumentation Tests', () => {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider();
+  const spanProcessor = new SimpleSpanProcessor(exporter);
+  provider.addSpanProcessor(spanProcessor);
+  provider.register();
+
+  afterEach(() => {
+    exporter.reset();
+  });
+  const webVitalsInstr = new WebVitalsInstrumentation({ enabled: false });
+  it('should create a CLS span', () => {
+    webVitalsInstr.onReportCLS({
+      name: 'CLS',
+      value: 0.2,
+      id: 'cls-id',
+      delta: 0.2,
+      rating: 'needs-improvement',
+      navigationType: 'back-forward',
+      entries: [],
+      attribution: {
+        largestShiftTarget: 'div#my-biggest-shift-element',
+        largestShiftTime: 100,
+        largestShiftValue: 0.2,
+        loadState: 'complete',
+        largestShiftEntry: {
+          hadRecentInput: true,
+          value: 0.2,
+          sources: [],
+          duration: 0.3,
+          entryType: 'layout-shift',
+          name: 'layout-shift',
+          startTime: 0.1,
+          toJSON() {
+            return '';
+          },
+        },
+      },
+    });
+
+    const span = exporter.getFinishedSpans()[0];
+    expect(span.name).toBe('CLS');
+    expect(span.instrumentationLibrary.name).toBe(
+      '@honeycombio/instrumentation-web-vitals',
+    );
+    expect(span.attributes).toEqual({
+      'cls.value': 0.2,
+      'cls.id': 'cls-id',
+      'cls.delta': 0.2,
+      'cls.rating': 'needs-improvement',
+      'cls.navigation_type': 'back-forward',
+      'cls.largest_shift_target': 'div#my-biggest-shift-element',
+      'cls.element': 'div#my-biggest-shift-element',
+      'cls.largest_shift_time': 100,
+      'cls.largest_shift_value': 0.2,
+      'cls.load_state': 'complete',
+      'cls.had_recent_input': true,
+    });
+  });
+
+  it('should create an LCP span', () => {
+    webVitalsInstr.onReportLCP({
+      name: 'LCP',
+      value: 2500,
+      id: 'lcp-id',
+      delta: 2500,
+      rating: 'good',
+      navigationType: 'back-forward',
+      entries: [],
+      attribution: {
+        element: 'div#lcp-element',
+        url: 'https://my-cool-image.stuff',
+        timeToFirstByte: 30,
+        resourceLoadTime: 20,
+        elementRenderDelay: 20,
+        resourceLoadDelay: 100,
+      },
+    });
+
+    const span = exporter.getFinishedSpans()[0];
+    expect(span.name).toBe('LCP');
+    expect(span.instrumentationLibrary.name).toBe(
+      '@honeycombio/instrumentation-web-vitals',
+    );
+    expect(span.attributes).toEqual({
+      'lcp.value': 2500,
+      'lcp.id': 'lcp-id',
+      'lcp.delta': 2500,
+      'lcp.rating': 'good',
+      'lcp.navigation_type': 'back-forward',
+      'lcp.element': 'div#lcp-element',
+      'lcp.url': 'https://my-cool-image.stuff',
+      'lcp.time_to_first_byte': 30,
+      'lcp.resource_load_delay': 100,
+      'lcp.resource_load_time': 20,
+      'lcp.element_render_delay': 20,
+    });
+  });
+
+  it('should create an INP span', () => {
+    webVitalsInstr.onReportINP({
+      name: 'INP',
+      value: 200,
+      id: 'inp-id',
+      delta: 200,
+      rating: 'good',
+      entries: [],
+      navigationType: 'back-forward',
+      attribution: {
+        eventTarget: 'div#inp-element',
+        eventType: 'input-delay',
+        loadState: 'complete',
+      },
+    });
+
+    const span = exporter.getFinishedSpans()[0];
+    expect(span.name).toBe('INP');
+    expect(span.instrumentationLibrary.name).toBe(
+      '@honeycombio/instrumentation-web-vitals',
+    );
+    expect(span.attributes).toEqual({
+      'inp.value': 200,
+      'inp.id': 'inp-id',
+      'inp.delta': 200,
+      'inp.rating': 'good',
+      'inp.navigation_type': 'back-forward',
+      'inp.element': 'div#inp-element',
+      'inp.event_type': 'input-delay',
+      'inp.load_state': 'complete',
+    });
+  });
+
+  it('should create an FCP span', () => {
+    webVitalsInstr.onReportFCP({
+      name: 'FCP',
+      value: 2500,
+      id: 'fcp-id',
+      delta: 2500,
+      rating: 'good',
+      navigationType: 'back-forward',
+      entries: [],
+      attribution: {
+        timeToFirstByte: 200,
+        firstByteToFCP: 400,
+        loadState: 'complete',
+      },
+    });
+    const span = exporter.getFinishedSpans()[0];
+    expect(span.name).toBe('FCP');
+    expect(span.instrumentationLibrary.name).toBe(
+      '@honeycombio/instrumentation-web-vitals',
+    );
+    expect(span.attributes).toEqual({
+      'fcp.value': 2500,
+      'fcp.id': 'fcp-id',
+      'fcp.delta': 2500,
+      'fcp.rating': 'good',
+      'fcp.navigation_type': 'back-forward',
+      'fcp.time_to_first_byte': 200,
+      'fcp.time_since_first_byte': 400,
+      'fcp.load_state': 'complete',
+    });
+  });
+
+  it('should create a TTFB span', () => {
+    webVitalsInstr.onReportTTFB({
+      name: 'TTFB',
+      value: 2500,
+      id: 'ttfb-id',
+      delta: 2500,
+      rating: 'good',
+      navigationType: 'back-forward',
+      entries: [],
+      attribution: {
+        waitingTime: 100,
+        dnsTime: 1000,
+        connectionTime: 200,
+        requestTime: 300,
+      },
+    });
+
+    const span = exporter.getFinishedSpans()[0];
+    expect(span.name).toBe('TTFB');
+    expect(span.instrumentationLibrary.name).toBe(
+      '@honeycombio/instrumentation-web-vitals',
+    );
+    expect(span.attributes).toEqual({
+      'ttfb.value': 2500,
+      'ttfb.id': 'ttfb-id',
+      'ttfb.delta': 2500,
+      'ttfb.rating': 'good',
+      'ttfb.navigation_type': 'back-forward',
+      'ttfb.waiting_time': 100,
+      'ttfb.dns_time': 1000,
+      'ttfb.connection_time': 200,
+      'ttfb.request_time': 300,
+    });
+  });
+
+  it('should create an FID span', () => {
+    webVitalsInstr.onReportFID({
+      name: 'FID',
+      value: 2500,
+      id: 'fid-id',
+      delta: 2500,
+      rating: 'good',
+      navigationType: 'back-forward',
+      entries: [],
+      attribution: {
+        eventTarget: 'div#fid-element',
+        eventType: 'input-delay',
+        loadState: 'complete',
+        eventTime: 0,
+        eventEntry: {
+          duration: 0.3,
+          entryType: 'layout-shift',
+          name: 'layout-shift',
+          startTime: 0.1,
+          cancelable: false,
+          processingStart: 0,
+          target: document.body,
+          toJSON() {
+            return '';
+          },
+        },
+      },
+    });
+
+    const span = exporter.getFinishedSpans()[0];
+    expect(span.name).toBe('FID');
+    expect(span.instrumentationLibrary.name).toBe(
+      '@honeycombio/instrumentation-web-vitals',
+    );
+    expect(span.attributes).toEqual({
+      'fid.value': 2500,
+      'fid.id': 'fid-id',
+      'fid.delta': 2500,
+      'fid.rating': 'good',
+      'fid.navigation_type': 'back-forward',
+      'fid.element': 'div#fid-element',
+      'fid.event_type': 'input-delay',
+      'fid.load_state': 'complete',
+    });
+  });
+});

--- a/test/web-vitals-instrumentation.test.ts
+++ b/test/web-vitals-instrumentation.test.ts
@@ -2,7 +2,6 @@ import { WebVitalsInstrumentation } from '../src/web-vitals-autoinstrumentation'
 import {
   BasicTracerProvider,
   InMemorySpanExporter,
-  ReadableSpan,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 


### PR DESCRIPTION
## Which problem is this PR solving?
Adds basic web vitals span based auto-instrumentation. Heavily based on [what will be available upstream](https://github.com/open-telemetry/opentelemetry-sandbox-web-js/blob/auto-instrumentation-poc/pkgs/instrumentations/web/web-vitals/src/web-vitals.ts), with the main difference being that the upstream instrumentation will be based on events, we'll have to support that down the line as well.

Should align very closely with the spec laid out in #61 
- Closes #12 

## Short description of the changes
- Adds web vitals auto-instrumentation based on the web-vitals package
- Adds option to specify which vitals should be tracked as well as a default of tracking CLS, LCP and INP.
- Adds tests to check spans created have the attributes we expect

## Out of scope for this PR
This PR is really aimed at getting the base instrumentation into the package so there will be follow up work to:
- Add more options based on the options available for configuring web-vitals in the main package
- Automatically initializing web vitals and the config to make that happen
- Smoke tests

## How to verify that this has the expected result
- Run the example app to see web vitals spans being sent.
