### PR TITLE
fix: update version and add version change to releasing doc

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,6 +8,7 @@
 ```
 
 - Confirm the version number update appears in `package.json` and `package-lock.json`.
+- Update `version.ts` with the new version number.
 - Update `CHANGELOG.md` with the changes since the last release. Consider automating with a command such as these two:
   - `git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline > new-in-this-release.log`
   - `git log --pretty='%C(green)%d%Creset- %s | %an'`

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.0.1';
+export const VERSION = '0.0.2';

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -1,0 +1,9 @@
+import { VERSION } from '../src/version';
+
+describe('sdk version', () => {
+  it('matches package.json version', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const expectedVersion = require('../package.json').version;
+    expect(VERSION).toBe(expectedVersion);
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?

- telemetry still shows 0.0.1 even though current release is 0.0.2. I missed updating this on the last release.

## Short description of the changes

- add step to releasing doc to update the version
- update the version to 0.0.2 since that is the current
- add test checking that version in `version.ts` matches version in `package.json`

## How to verify that this has the expected result

tests pass, we remember to update version next time 😅 