### PR TITLE
docs: add JS docs for web vitals instrumentation

### DIFF
--- a/examples/custom-with-collector-ts/package-lock.json
+++ b/examples/custom-with-collector-ts/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../..": {
       "name": "@honeycombio/opentelemetry-web",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "~1.7.0",
@@ -34,11 +34,12 @@
         "@opentelemetry/sdk-trace-base": "~1.21.0",
         "@opentelemetry/sdk-trace-web": "~1.21.0",
         "@opentelemetry/semantic-conventions": "~1.21.0",
-        "@typescript-eslint/eslint-plugin": "^6.20.0",
-        "@typescript-eslint/parser": "^6.20.0",
+        "@typescript-eslint/eslint-plugin": "^7.0.2",
+        "@typescript-eslint/parser": "^7.0.2",
         "axios": "^1.6.7",
         "eslint-config-prettier": "^9.1.0",
-        "prettier": "^3.2.4"
+        "prettier": "^3.2.4",
+        "web-vitals": "^3.5.2"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",


### PR DESCRIPTION
## Which problem is this PR solving?
Adds JS docs for web vitals auto-instrumentation to make IDE support and documentation better.

## Short description of the changes
- JS docs for class & all config options

## How to verify that this has the expected result
- Pull this branch and hover over `WebVitalsInstrumentation` in the example (or anywhere). You should see a description of the class.
