### PR TITLE
feat: add support for classic ingest keys

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -25,14 +25,25 @@ export const defaultOptions: HoneycombOptions = {
 export const createHoneycombSDKLogMessage = (message: string) =>
   `@honeycombio/opentelemetry-web: ${message}`;
 
+const classicKeyRegex = /^[a-f0-9]*$/;
+const ingestClassicKeyRegex = /^hc[a-z]ic_[a-z0-9]*$/;
+
 /**
- * Determines whether the passed in apikey is classic (32 chars) or not.
+ * Determines whether the passed in apikey is classic or not.
  *
  * @param apikey the apikey
  * @returns a boolean to indicate if the apikey was a classic key
  */
 export function isClassic(apikey?: string): boolean {
-  return apikey?.length === 32;
+  if (apikey === null || apikey === undefined || apikey.length === 0) {
+    return false;
+  }
+  else if(apikey.length === 32) {
+    return classicKeyRegex.test(apikey);
+  } else if(apikey.length === 64) {
+    return ingestClassicKeyRegex.test(apikey);
+  }
+  return false;
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -35,7 +35,7 @@ const ingestClassicKeyRegex = /^hc[a-z]ic_[a-z0-9]*$/;
  * @returns a boolean to indicate if the apikey was a classic key
  */
 export function isClassic(apikey?: string): boolean {
-  if (apikey === null || apikey === undefined || apikey.length === 0) {
+  if (apikey == null || apikey.length === 0) {
     return false;
   }
   else if(apikey.length === 32) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,10 +37,9 @@ const ingestClassicKeyRegex = /^hc[a-z]ic_[a-z0-9]*$/;
 export function isClassic(apikey?: string): boolean {
   if (apikey == null || apikey.length === 0) {
     return false;
-  }
-  else if(apikey.length === 32) {
+  } else if (apikey.length === 32) {
     return classicKeyRegex.test(apikey);
-  } else if(apikey.length === 64) {
+  } else if (apikey.length === 64) {
     return ingestClassicKeyRegex.test(apikey);
   }
   return false;

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -6,48 +6,51 @@ import {
   maybeAppendTracesPath,
 } from '../src/util';
 
-
 describe('isClassic', () => {
   it.each([
     {
-      testString: "hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc",
-      name: "full ingest key string, non classic",
-      expected: false
+      testString:
+        'hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc',
+      name: 'full ingest key string, non classic',
+      expected: false,
     },
     {
-      testString: "hcxik_01hqk4k20cjeh63wca8vva5stw",
-      name: "ingest key id, non classic",
-      expected: false
+      testString: 'hcxik_01hqk4k20cjeh63wca8vva5stw',
+      name: 'ingest key id, non classic',
+      expected: false,
     },
     {
-      testString: "hcaic_1234567890123456789012345678901234567890123456789012345678",
-      name: "full ingest key string, classic",
-      expected: true
+      testString:
+        'hcaic_1234567890123456789012345678901234567890123456789012345678',
+      name: 'full ingest key string, classic',
+      expected: true,
     },
     {
-      testString: "hcaic_12345678901234567890123456",
-      name: "ingest key id, classic",
-      expected: false
+      testString: 'hcaic_12345678901234567890123456',
+      name: 'ingest key id, classic',
+      expected: false,
     },
     {
-      testString: "kgvSpPwegJshQkuowXReLD",
-      name: "v2 configuration key",
-      expected: false
+      testString: 'kgvSpPwegJshQkuowXReLD',
+      name: 'v2 configuration key',
+      expected: false,
     },
     {
-      testString: "12345678901234567890123456789012",
-      name: "classic key",
-      expected: true
+      testString: '12345678901234567890123456789012',
+      name: 'classic key',
+      expected: true,
     },
     {
       testString: undefined,
-      name: "undefined",
-      expected: false
-    }
-
-  ])("test case $name", (testCase: {testString?: string, name: string, expected: boolean}) => {
-    expect(isClassic(testCase.testString)).toEqual(testCase.expected);
-  });
+      name: 'undefined',
+      expected: false,
+    },
+  ])(
+    'test case $name',
+    (testCase: { testString?: string; name: string; expected: boolean }) => {
+      expect(isClassic(testCase.testString)).toEqual(testCase.expected);
+    },
+  );
 });
 
 describe('maybeAppendTracesPath', () => {

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -6,22 +6,47 @@ import {
   maybeAppendTracesPath,
 } from '../src/util';
 
-// classic keys are 32 chars long
-const classicApiKey = 'this is a string that is 32 char';
-// non-classic keys are 22 chars log
-const apiKey = 'an api key for 22 char';
 
 describe('isClassic', () => {
-  it('should return true for a classic key', () => {
-    expect(isClassic(classicApiKey)).toBe(true);
-  });
+  it.each([
+    {
+      testString: "hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc",
+      name: "full ingest key string, non classic",
+      expected: false
+    },
+    {
+      testString: "hcxik_01hqk4k20cjeh63wca8vva5stw",
+      name: "ingest key id, non classic",
+      expected: false
+    },
+    {
+      testString: "hcaic_1234567890123456789012345678901234567890123456789012345678",
+      name: "full ingest key string, classic",
+      expected: true
+    },
+    {
+      testString: "hcaic_12345678901234567890123456",
+      name: "ingest key id, classic",
+      expected: false
+    },
+    {
+      testString: "kgvSpPwegJshQkuowXReLD",
+      name: "v2 configuration key",
+      expected: false
+    },
+    {
+      testString: "12345678901234567890123456789012",
+      name: "classic key",
+      expected: true
+    },
+    {
+      testString: undefined,
+      name: "undefined",
+      expected: false
+    }
 
-  it('should return false for a non-classic key', () => {
-    expect(isClassic(apiKey)).toBe(false);
-  });
-
-  it('should return false for an undefined key', () => {
-    expect(isClassic(undefined)).toBe(false);
+  ])("test case $name", (testCase) => {
+    expect(isClassic(testCase.testString)).toEqual(testCase.expected);
   });
 });
 

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -45,7 +45,7 @@ describe('isClassic', () => {
       expected: false
     }
 
-  ])("test case $name", (testCase) => {
+  ])("test case $name", (testCase: {testString?: string, name: string, expected: boolean}) => {
     expect(isClassic(testCase.testString)).toEqual(testCase.expected);
   });
 });

--- a/test/validate-options.test.ts
+++ b/test/validate-options.test.ts
@@ -27,9 +27,9 @@ afterAll(() => {
 });
 
 // classic keys are 32 chars long
-const classicApiKey = 'this is a string that is 32 char';
+const classicApiKey = '12345678901234567890123456789012';
 // non-classic keys are 22 chars log
-const apiKey = 'an api key for 22 char';
+const apiKey = 'kgvSpPwegJshQkuowXReLD';
 
 describe('console warnings', () => {
   describe('when skipOptionsValidation is true', () => {

--- a/test/validate-options.test.ts
+++ b/test/validate-options.test.ts
@@ -26,9 +26,9 @@ afterAll(() => {
   warningSpy.mockRestore();
 });
 
-// classic keys are 32 chars long
+// non-ingest classic keys are 32 chars long
 const classicApiKey = '12345678901234567890123456789012';
-// non-classic keys are 22 chars log
+// non-ingest non-classic keys are 22 chars log
 const apiKey = 'kgvSpPwegJshQkuowXReLD';
 
 describe('console warnings', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

We've released Ingest Keys, but need to update the key detection logic to allow Ingest Keys to be used to send data to Classic environments.

## Short description of the changes
- updates the Classic API Key detection logic to understand the shape of a Classic Ingest Key
- updates tests with a more comprehensive list of cases

## How to verify that this has the expected result

It should be possible to use [an ingest key](https://docs.honeycomb.io/working-with-your-data/settings/api-keys/#ingest-keys-1) pointed to a classic environment after this change. Please note that the ability to create ingest keys in classic environments isn't yet publicly available (since we need to update this library and others to understand classic ingest keys).
