### PR TITLE
feat: Auto-enable web vitals instrumentation

### DIFF
--- a/examples/custom-with-collector-ts/src/index.ts
+++ b/examples/custom-with-collector-ts/src/index.ts
@@ -21,11 +21,6 @@ const trackButton = (onClick: { (): void; (): void }) => {
     'button-important',
   ) as HTMLButtonElement;
   const tracer = trace.getTracer('click-tracer');
-  button.addEventListener('click', () => {
-    console.log(
-      'click event is automatically captured by the auto-instrumentation',
-    );
-  });
 
   button.onclick = () =>
     tracer.startActiveSpan(`clicked the button`, (span) => {

--- a/examples/hello-world-web/index.js
+++ b/examples/hello-world-web/index.js
@@ -1,7 +1,4 @@
-import {
-  HoneycombWebSDK,
-  WebVitalsInstrumentation,
-} from '@honeycombio/opentelemetry-web';
+import { HoneycombWebSDK } from '@honeycombio/opentelemetry-web';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 
 const main = () => {
@@ -12,10 +9,7 @@ const main = () => {
     apiKey: 'api-key',
     serviceName: 'web-distro',
     debug: true,
-    instrumentations: [
-      getWebAutoInstrumentations(),
-      new WebVitalsInstrumentation(),
-    ], // add auto-instrumentation
+    instrumentations: [getWebAutoInstrumentations()], // add auto-instrumentation
   });
   sdk.start();
 };

--- a/examples/hello-world-web/index.js
+++ b/examples/hello-world-web/index.js
@@ -10,6 +10,9 @@ const main = () => {
     serviceName: 'web-distro',
     debug: true,
     instrumentations: [getWebAutoInstrumentations()], // add auto-instrumentation
+    // webVitalsInstrumentationConfig: {
+    //   enabled: false,
+    // },
   });
   sdk.start();
 };

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -5,6 +5,8 @@ load test_helpers/utilities
 CONTAINER_NAME="app-hello-world-web"
 DOCUMENT_LOAD_SCOPE="@opentelemetry/instrumentation-document-load"
 USER_INTERACTION_SCOPE="@opentelemetry/instrumentation-user-interaction"
+WEB_VITALS_SCOPE="@honeycombio/instrumentation-web-vitals"
+
 CUSTOM_TRACER_NAME="click-tracer"
 
 setup_file() {
@@ -91,11 +93,16 @@ teardown_file() {
 
 @test "Custom instrumentation adds custom attribute" {
 	result=$(span_attributes_for ${CUSTOM_TRACER_NAME} | jq "select(.key == \"message\").value.stringValue")
-	assert_equal "$result" '"important message"'
+	assert_contains "$result" '"important message"'
 }
 
 @test "BaggageSpanProcessor: key-values added to baggage appear on child spans" {
 	result=$(span_attributes_for ${CUSTOM_TRACER_NAME} | jq "select(.key == \"username\").value.stringValue")
-	assert_equal "$result" '"alice"
+	assert_contains "$result" '"alice"
 "alice"'
+}
+
+@test "Auto instrumentation produces web vitals spans" {
+  result=$(span_names_for ${WEB_VITALS_SCOPE})
+  assert_not_empty "$result"
 }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -93,12 +93,12 @@ teardown_file() {
 
 @test "Custom instrumentation adds custom attribute" {
 	result=$(span_attributes_for ${CUSTOM_TRACER_NAME} | jq "select(.key == \"message\").value.stringValue")
-	assert_contains "$result" '"important message"'
+	assert_equal "$result" '"important message"'
 }
 
 @test "BaggageSpanProcessor: key-values added to baggage appear on child spans" {
 	result=$(span_attributes_for ${CUSTOM_TRACER_NAME} | jq "select(.key == \"username\").value.stringValue")
-	assert_contains "$result" '"alice"
+	assert_equal "$result" '"alice"
 "alice"'
 }
 

--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -12,12 +12,17 @@ import { WebVitalsInstrumentation } from './web-vitals-autoinstrumentation';
 
 export class HoneycombWebSDK extends WebSDK {
   constructor(options?: HoneycombOptions) {
+    const instrumentations = [...(options?.instrumentations || [])];
+    // Automatically include web vitals instrumentation unless explicitly set to false
+    if (options?.webVitalsInstrumentationConfig?.enabled !== false) {
+      instrumentations.push(
+        new WebVitalsInstrumentation(options?.webVitalsInstrumentationConfig),
+      );
+    }
+
     super({
       ...options,
-      instrumentations: [
-        new WebVitalsInstrumentation(options?.webVitalsInstrumentationConfig),
-        ...(options?.instrumentations || []),
-      ],
+      instrumentations,
       resource: mergeResources([
         configureBrowserAttributesResource(),
         configureEntryPageResource(options?.entryPageAttributes),

--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -15,7 +15,7 @@ export class HoneycombWebSDK extends WebSDK {
     super({
       ...options,
       instrumentations: [
-        new WebVitalsInstrumentation(),
+        new WebVitalsInstrumentation(options?.webVitalsInstrumentationConfig),
         ...(options?.instrumentations || []),
       ],
       resource: mergeResources([

--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -8,11 +8,16 @@ import { configureDebug } from './honeycomb-debug';
 import { configureSpanProcessors } from './span-processor-builder';
 import { configureDeterministicSampler } from './deterministic-sampler';
 import { validateOptionsWarnings } from './validate-options';
+import { WebVitalsInstrumentation } from './web-vitals-autoinstrumentation';
 
 export class HoneycombWebSDK extends WebSDK {
   constructor(options?: HoneycombOptions) {
     super({
       ...options,
+      instrumentations: [
+        new WebVitalsInstrumentation(),
+        ...(options?.instrumentations || []),
+      ],
       resource: mergeResources([
         configureBrowserAttributesResource(),
         configureEntryPageResource(options?.entryPageAttributes),

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ import {
   SpanLimits,
   SpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
+import { WebVitalsInstrumentationConfig } from './web-vitals-autoinstrumentation';
 
 export interface WebSDKConfiguration {
   autoDetectResources: boolean;
@@ -118,6 +119,9 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
    * ```
    */
   entryPageAttributes?: false | EntryPageConfig;
+
+  /** Config options for web vitals instrumentation. Enabled by default. */
+  webVitalsInstrumentationConfig?: WebVitalsInstrumentationConfig;
 }
 
 /* Configure which fields to include in the `entry_page` resource attributes. By default,

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,6 +20,9 @@ export const defaultOptions: HoneycombOptions = {
   sampleRate: 1,
   skipOptionsValidation: false,
   localVisualizations: false,
+  webVitalsInstrumentationConfig: {
+    enabled: true,
+  },
 };
 
 export const createHoneycombSDKLogMessage = (message: string) =>

--- a/src/web-vitals-autoinstrumentation.ts
+++ b/src/web-vitals-autoinstrumentation.ts
@@ -81,6 +81,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
   readonly fidOpts?: VitalOpts;
   readonly fcpOpts?: VitalOpts;
   readonly ttfbOpts?: VitalOpts;
+  readonly enabled?: boolean;
 
   constructor(
     config: WebVitalsInstrumentationConfig = {
@@ -115,10 +116,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     this.fidOpts = config?.fid;
     this.fcpOpts = config?.fcp;
     this.ttfbOpts = config?.ttfb;
-
-    if (config.enabled === true) {
-      this.enable();
-    }
+    this.enabled = config?.enabled;
   }
 
   init() {}
@@ -308,6 +306,10 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
   };
 
   enable(): void {
+    if (!this.enabled) {
+      this._diag.debug(`Instrumentation disabled`);
+      return;
+    }
     this._diag.debug(`Sending spans for ${this.vitalsToTrack.join(',')}`);
 
     if (this.vitalsToTrack.includes('CLS')) {

--- a/test/honeycomb-debug.test.ts
+++ b/test/honeycomb-debug.test.ts
@@ -49,22 +49,23 @@ describe('when debug is set to true', () => {
       };
       new HoneycombWebSDK(testConfig);
       expect(consoleSpy).toHaveBeenNthCalledWith(
-        2,
+        3,
         '@honeycombio/opentelemetry-web: 🐝 Honeycomb Web SDK Debug Mode Enabled 🐝',
       );
       expect(consoleSpy).toHaveBeenNthCalledWith(
-        3,
+        4,
         `@honeycombio/opentelemetry-web: API Key configured for traces: '${testConfig.apiKey}'`,
       );
       expect(consoleSpy).toHaveBeenNthCalledWith(
-        4,
+        5,
         `@honeycombio/opentelemetry-web: Service Name configured for traces: '${testConfig.serviceName}'`,
       );
       expect(consoleSpy).toHaveBeenNthCalledWith(
-        5,
+        6,
         `@honeycombio/opentelemetry-web: Endpoint configured for traces: '${testConfig.endpoint}/${TRACES_PATH}'`,
       );
-      expect(consoleSpy.mock.calls[5][0]).toContain(
+      expect(consoleSpy).toHaveBeenNthCalledWith(
+        7,
         `@honeycombio/opentelemetry-web: Sample Rate configured for traces: '${testConfig.sampleRate}'`,
       );
     });


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #100 

Automatically includes `WebVitalsInstrumentation` in array of instrumentations when SDK is initialized, unless the config option is set explicitly to `false`. This is so that when the SDK is configured, users get web vitals spans without having to configure them explicitly.

## Short description of the changes
- Adds `WebVitalsInstrumentation` as a default instrumentation in the SDK
- Adds support for configuring `WebVitalsInstrumentation`, including turning it off and supporting the other config values.
- Adds smoke tests for web vitals spans

**Note**: one interesting conflict that was surfaced by smoke tests (shout out to smoke tests, so glad we have them) is that when the web vitals instrumentation is initialized and includes sending spans for `INP`, there is an [event listener added by the base `web-vitals` library](https://github.com/GoogleChrome/web-vitals/blob/8058a007c9878c2b56c787040d4e8ca282dc203a/test/views/inp.njk#L85). This means that if a user also adds an event listener for click or other events, they will be collected twice. We should make a note of this in our documentation. For now I removed the event listener in the example to make sure the click is only collected once.

## How to verify that this has the expected result
- Run the example and see web vitals spans in the console
- Set the config to false and verify that no web vitals spans are being sent


Co-authored-by: Wolfgang Therrien <wolfgangcodes@users.noreply.github.com>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206754510479286