### PR TITLE
docs: Update README.md to include link to docs site page

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Build and run your application, and then look for data in Honeycomb. On the Home
 
 ![Honeycomb screen, with "Home" circled on the left, and the dropdown circled at the top.](docs/honeycomb-home.png)
 
+Refer to our [Honeycomb documentation](https://docs.honeycomb.io/get-started/start-building/rum/) for more information on instrumentation and troubleshooting.
+
 ## SDK Configuration
 
 Pass these options to the HoneycombWebSDK:


### PR DESCRIPTION
## Which problem is this PR solving?

Addresses lack of path for users to access troubleshooting and additional resources.

## Short description of the changes

This PR updates the repo README to include a link to the Honeycomb for RUM page in Honeycomb Docs.

## How to verify that this has the expected result

If the link works, then we're good!