### PR TITLE
docs: README.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This project provides a convenient distribution of all the code required to get 
 npm install @honeycombio/opentelemetry-web @opentelemetry/auto-instrumentations-web
 ```
 
-2. [Get a Honeycomb API key]([https://docs.honeycomb.io/quickstart/#create-a-honeycomb-account).
+2. [Get a Honeycomb API key](https://docs.honeycomb.io/get-started/configure/environments/manage-api-keys/#find-api-keys).
 
 3. Initialize tracing at the start of your application:
 

--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ This project provides a convenient distribution of all the code required to get 
 
 ## Getting started
 
-Install this library:
+1. Install this library:
 
 ```sh
 npm install @honeycombio/opentelemetry-web @opentelemetry/auto-instrumentations-web
 ```
 
-[Get a Honeycomb API key](https://docs.honeycomb.io/quickstart/#create-a-honeycomb-account).
+2. [Get a Honeycomb API key]([https://docs.honeycomb.io/quickstart/#create-a-honeycomb-account).
 
-Initialize tracing at the start of your application:
+3. Initialize tracing at the start of your application:
 
 ```js
 import { HoneycombWebSDK, WebVitalsInstrumentation } from '@honeycombio/opentelemetry-web';
@@ -64,7 +64,7 @@ const sdk = new HoneycombWebSDK({
 sdk.start();
 ```
 
-Build and run your application, and then look for data in Honeycomb. On the Home screen, choose your application by looking for the service name in the Dataset dropdown at the top. Data should populate.
+4. Build and run your application, and then look for data in Honeycomb. On the Home screen, choose your application by looking for the service name in the Dataset dropdown at the top. Data should populate.
 
 ![Honeycomb screen, with "Home" circled on the left, and the dropdown circled at the top.](docs/honeycomb-home.png)
 


### PR DESCRIPTION
## Which problem is this PR solving?

An outdated link to important information about how to find your Honeycomb API Key.

## Short description of the changes

This PR updates an outdated docs.honeycomb.io link to the correct location. In addition, numbers are added to the steps in the Getting started section.

## How to verify that this has the expected result

Does clicking on the docs link get you to the desired location?