### PR TITLE
fix: add opentelemetry/core as a dependency to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "~1.8.0",
+        "@opentelemetry/core": "^1.24.0",
         "@opentelemetry/exporter-trace-otlp-http": "~0.50.0",
         "@opentelemetry/instrumentation": "~0.50.0",
         "@opentelemetry/opentelemetry-browser-detector": "~0.50.0",
@@ -1351,17 +1352,25 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
-      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.0.tgz",
+      "integrity": "sha512-FP2oN7mVPqcdxJDTTnKExj4mi91EH+DNuArKfHTjPuJWe2K1JfMIVXNfahw1h3onJxQnxS8K0stKkogX05s+Aw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.23.0"
+        "@opentelemetry/semantic-conventions": "1.24.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.0.tgz",
+      "integrity": "sha512-yL0jI6Ltuz8R+Opj7jClGrul6pOoYrdfVmzQS4SITXRPH7I5IRZbrwe/6/v8v4WYMa6MYZG480S1+uc/IGfqsA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
@@ -1380,6 +1389,20 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
@@ -1430,6 +1453,20 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
     "node_modules/@opentelemetry/otlp-transformer": {
       "version": "0.50.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.50.0.tgz",
@@ -1449,12 +1486,40 @@
         "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
     "node_modules/@opentelemetry/resources": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
       "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
       "dependencies": {
         "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "dependencies": {
         "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
@@ -1480,6 +1545,20 @@
         "@opentelemetry/api-logs": ">=0.39.1"
       }
     },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-metrics": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.23.0.tgz",
@@ -1494,6 +1573,20 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
@@ -1512,6 +1605,20 @@
         "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-trace-web": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.23.0.tgz",
@@ -1519,6 +1626,20 @@
       "dependencies": {
         "@opentelemetry/core": "1.23.0",
         "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "dependencies": {
         "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
@@ -8959,11 +9080,18 @@
       }
     },
     "@opentelemetry/core": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
-      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.0.tgz",
+      "integrity": "sha512-FP2oN7mVPqcdxJDTTnKExj4mi91EH+DNuArKfHTjPuJWe2K1JfMIVXNfahw1h3onJxQnxS8K0stKkogX05s+Aw==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.23.0"
+        "@opentelemetry/semantic-conventions": "1.24.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.24.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.0.tgz",
+          "integrity": "sha512-yL0jI6Ltuz8R+Opj7jClGrul6pOoYrdfVmzQS4SITXRPH7I5IRZbrwe/6/v8v4WYMa6MYZG480S1+uc/IGfqsA=="
+        }
       }
     },
     "@opentelemetry/exporter-trace-otlp-http": {
@@ -8976,6 +9104,16 @@
         "@opentelemetry/otlp-transformer": "0.50.0",
         "@opentelemetry/resources": "1.23.0",
         "@opentelemetry/sdk-trace-base": "1.23.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+          "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation": {
@@ -9006,6 +9144,16 @@
       "integrity": "sha512-JUmjmrCmE1/fc4LjCQMqLfudgSl5OpUkzx7iA94b4jgeODM7zWxUoVXL7/CT7fWf47Cn+pmKjMvTCSESqZZ3mA==",
       "requires": {
         "@opentelemetry/core": "1.23.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+          "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        }
       }
     },
     "@opentelemetry/otlp-transformer": {
@@ -9019,6 +9167,16 @@
         "@opentelemetry/sdk-logs": "0.50.0",
         "@opentelemetry/sdk-metrics": "1.23.0",
         "@opentelemetry/sdk-trace-base": "1.23.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+          "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        }
       }
     },
     "@opentelemetry/resources": {
@@ -9028,6 +9186,16 @@
       "requires": {
         "@opentelemetry/core": "1.23.0",
         "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+          "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        }
       }
     },
     "@opentelemetry/sdk-logs": {
@@ -9037,6 +9205,16 @@
       "requires": {
         "@opentelemetry/core": "1.23.0",
         "@opentelemetry/resources": "1.23.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+          "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        }
       }
     },
     "@opentelemetry/sdk-metrics": {
@@ -9047,6 +9225,16 @@
         "@opentelemetry/core": "1.23.0",
         "@opentelemetry/resources": "1.23.0",
         "lodash.merge": "^4.6.2"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+          "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        }
       }
     },
     "@opentelemetry/sdk-trace-base": {
@@ -9057,6 +9245,16 @@
         "@opentelemetry/core": "1.23.0",
         "@opentelemetry/resources": "1.23.0",
         "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+          "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        }
       }
     },
     "@opentelemetry/sdk-trace-web": {
@@ -9067,6 +9265,16 @@
         "@opentelemetry/core": "1.23.0",
         "@opentelemetry/sdk-trace-base": "1.23.0",
         "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+          "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        }
       }
     },
     "@opentelemetry/semantic-conventions": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@opentelemetry/core": "^1.24.0",
     "@opentelemetry/api": "~1.8.0",
     "@opentelemetry/exporter-trace-otlp-http": "~0.50.0",
     "@opentelemetry/instrumentation": "~0.50.0",


### PR DESCRIPTION
Solves #127 

This will fix support for package managers like `pnpm` that require you to be very explicit about your dependencies

<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #127 

## Short description of the changes

Abides by requirements outlined here https://pnpm.io/how-peers-are-resolved

Given this package doesn't produce a bundle and is distributed using transpiled source code you still need the dependency manager to have the user resolve what is imported. The source code of this project directly imports this package https://github.com/search?q=repo%3Ahoneycombio%2Fhoneycomb-opentelemetry-web%20%22%40opentelemetry%2Fcore%22&type=code, thus this project relies on its presence.

## How to verify that this has the expected result

Import this project and try to run it through webpack using `pnpm` as the package manager for the project. It will fail because the package I'm adding in this diff is never resolved in node_modules

