### PR TITLE
feat: Add headers option to main SDK config

### DIFF
--- a/src/http-json-trace-exporter.ts
+++ b/src/http-json-trace-exporter.ts
@@ -19,6 +19,7 @@ export function configureHoneycombHttpJsonTraceExporter(
     headers: {
       [TEAM_HEADER_KEY]: apiKey,
       [DATASET_HEADER_KEY]: isClassic(apiKey) ? options?.dataset : undefined,
+      ...options?.headers,
     },
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,9 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
    */
   endpoint?: string;
 
+  /** Optionally pass extra headers to the exporter. Commonly used if sending to a collector that requires authentication */
+  headers?: { [key: string]: string | number };
+
   /** The API endpoint where traces telemetry is sent. Defaults to endpoint if not set. */
   tracesEndpoint?: string;
 

--- a/test/http-json-trace-exporter.test.ts
+++ b/test/http-json-trace-exporter.test.ts
@@ -10,13 +10,13 @@ const dataset = 'my-dataset';
 const apikey = '0000000000000000000000'; // 22 chars
 const classicApikey = '00000000000000000000000000000000'; // 32 chars
 
-test('it should return an OTLPTraceExporter', () => {
-  const traceExporter = configureHoneycombHttpJsonTraceExporter();
-  expect(traceExporter).toBeInstanceOf(OTLPTraceExporter);
-});
+describe('HTTP JSON Trace Exporter Tests', () => {
+  test('it should return an OTLPTraceExporter', () => {
+    const traceExporter = configureHoneycombHttpJsonTraceExporter();
+    expect(traceExporter).toBeInstanceOf(OTLPTraceExporter);
+  });
 
-describe('with a regular apikey', () => {
-  test('it should set the team and not the dataset headers', () => {
+  test('it should set the team and not the dataset headers for a regular api key', () => {
     const traceExporter = configureHoneycombHttpJsonTraceExporter({
       apiKey: apikey,
       dataset: dataset,
@@ -25,10 +25,8 @@ describe('with a regular apikey', () => {
     expect(traceExporter.headers[TEAM_HEADER_KEY]).toBe(apikey);
     expect(traceExporter.headers[DATASET_HEADER_KEY]).toBeUndefined();
   });
-});
 
-describe('with a classic apikey', () => {
-  test('it should set the team and dataset headers', () => {
+  test('it should set the team and dataset headers for a classic api key', () => {
     const traceExporter = configureHoneycombHttpJsonTraceExporter({
       apiKey: classicApikey,
       dataset: dataset,
@@ -36,5 +34,14 @@ describe('with a classic apikey', () => {
     expect(traceExporter.url).toBe(DEFAULT_API_ENDPOINT + '/v1/traces');
     expect(traceExporter.headers[TEAM_HEADER_KEY]).toBe(classicApikey);
     expect(traceExporter.headers[DATASET_HEADER_KEY]).toBe(dataset);
+  });
+
+  test('it adds custom headers', () => {
+    const traceExporter = configureHoneycombHttpJsonTraceExporter({
+      headers: {
+        'x-test-header': 'my-cool-header',
+      },
+    });
+    expect(traceExporter.headers['x-test-header']).toBe('my-cool-header');
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #134 

## Short description of the changes
Add `headers` config object that gets passed to the trace exporter. 

## How to verify that this has the expected result
In the example app, add a `headers` object with custom headers. Run the app in the browser and check the network tab to see custom headers being added.
