### PR TITLE
fix: add opentelemetry/core as a peerdependency to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "~1.8.0",
+        "@opentelemetry/core": "~1.24.0",
         "@opentelemetry/exporter-trace-otlp-http": "~0.51.0",
         "@opentelemetry/instrumentation": "~0.51.0",
         "@opentelemetry/opentelemetry-browser-detector": "~0.51.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@opentelemetry/core": "~1.24.0",
     "@opentelemetry/api": "~1.8.0",
     "@opentelemetry/exporter-trace-otlp-http": "~0.51.0",
     "@opentelemetry/instrumentation": "~0.51.0",


### PR DESCRIPTION
Solves #127
Closes #128 

This will fix support for package managers like `pnpm` that require you to be very explicit about your dependencies

## Which problem is this PR solving?

Closes #128 

@Aghassi contributed a fix in that PR but we merged other PRs and created merge conflicts. This PR resolves those merge conflicts on their behalf.