### PR TITLE
fix: Add missing dependency shimmer to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@opentelemetry/sdk-trace-web": "~1.24.0",
         "@opentelemetry/semantic-conventions": "~1.24.0",
         "axios": "^1.6.7",
+        "shimmer": "^1.2.1",
         "ua-parser-js": "^1.0.37",
         "web-vitals": "^3.5.2"
       },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@opentelemetry/sdk-trace-web": "~1.24.0",
     "@opentelemetry/semantic-conventions": "~1.24.0",
     "axios": "^1.6.7",
+    "shimmer": "^1.2.1",
     "ua-parser-js": "^1.0.37",
     "web-vitals": "^3.5.2"
   }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

Solves #149

## Which problem is this PR solving?

- Closes #149

## Short description of the changes

#140 added a dependency on [shimmer](https://www.npmjs.com/package/shimmer) in [src/web-vitals-autoinstrumentation.ts#L39](https://github.com/honeycombio/honeycomb-opentelemetry-web/blob/main/src/web-vitals-autoinstrumentation.ts#L39), but this is not defined in `package.json`. This change adds an explicit dependency for this.

## How to verify that this has the expected result

Run `npx depcheck` to verify that all dependencies in the code are referenced in `package.json`.