### PR TITLE
feat: drop axios requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@opentelemetry/sdk-trace-base": "~1.24.0",
         "@opentelemetry/sdk-trace-web": "~1.24.0",
         "@opentelemetry/semantic-conventions": "~1.24.0",
-        "axios": "^1.6.7",
         "shimmer": "^1.2.1",
         "ua-parser-js": "^1.0.37",
         "web-vitals": "^3.5.2"
@@ -2337,7 +2336,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2374,34 +2374,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
-    },
-    "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/axios/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2911,6 +2883,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3204,6 +3177,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4019,25 +3993,6 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -6112,6 +6067,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6120,6 +6076,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9827,7 +9784,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -9852,33 +9810,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
-    },
-    "axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-      "requires": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "proxy-from-env": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-        }
-      }
     },
     "babel-jest": {
       "version": "29.7.0",
@@ -10232,6 +10163,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -10461,7 +10393,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -11093,11 +11026,6 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true,
       "peer": true
-    },
-    "follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -12620,12 +12548,14 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@opentelemetry/core": "~1.24.0",
     "@opentelemetry/api": "~1.8.0",
+    "@opentelemetry/core": "~1.24.0",
     "@opentelemetry/exporter-trace-otlp-http": "~0.51.0",
     "@opentelemetry/instrumentation": "~0.51.0",
     "@opentelemetry/opentelemetry-browser-detector": "~0.51.0",
@@ -51,7 +51,6 @@
     "@opentelemetry/sdk-trace-base": "~1.24.0",
     "@opentelemetry/sdk-trace-web": "~1.24.0",
     "@opentelemetry/semantic-conventions": "~1.24.0",
-    "axios": "^1.6.7",
     "shimmer": "^1.2.1",
     "ua-parser-js": "^1.0.37",
     "web-vitals": "^3.5.2"

--- a/src/console-trace-link-exporter.ts
+++ b/src/console-trace-link-exporter.ts
@@ -61,7 +61,7 @@ class ConsoleTraceLinkExporter implements SpanExporter {
             respData.environment?.slug,
           );
         } else {
-          console.log(FAILED_AUTH_FOR_LOCAL_VISUALIZATIONS);
+          throw new Error();
         }
       })
       .catch(() => {

--- a/test/console-trace-link-exporter.test.ts
+++ b/test/console-trace-link-exporter.test.ts
@@ -1,4 +1,8 @@
-import { buildTraceUrl } from '../src/console-trace-link-exporter';
+import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import {
+  buildTraceUrl,
+  configureConsoleTraceLinkExporter,
+} from '../src/console-trace-link-exporter';
 
 const apikey = '000000000000000000000000';
 const classicApikey = '00000000000000000000000000000000';
@@ -25,6 +29,151 @@ describe('buildTraceUrl', () => {
     );
     expect(url).toBe(
       'https://ui.honeycomb.io/my-team/datasets/my-service/trace?trace_id',
+    );
+  });
+});
+
+describe('ConsoleTraceLinkExporter', () => {
+  let originalFetch: typeof global.fetch;
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    originalFetch = global.fetch;
+    global.fetch = jest.fn();
+
+    consoleLogSpy = jest.spyOn(console, 'log');
+  });
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('makes request and logs the trace url', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          team: { slug: 'test-team' },
+          environment: { slug: 'test-env' },
+        }),
+    });
+
+    const exporter = configureConsoleTraceLinkExporter({
+      apiKey: apikey,
+      serviceName: 'test-service',
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.honeycomb.io/1/auth',
+      {
+        headers: {
+          'x-honeycomb-team': apikey,
+        },
+      },
+    );
+
+    // @ts-expect-error we only include the properties we need
+    const fakeSpan: ReadableSpan = {
+      spanContext: () => ({
+        traceId: '1234',
+        spanId: '1234',
+        traceFlags: 0,
+      }),
+    };
+
+    // wait for promises to resolve
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    await new Promise(process.nextTick);
+
+    // all of the fetch() promises have to resolve before we can export
+    exporter.export([fakeSpan], () => {});
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '@honeycombio/opentelemetry-web: Honeycomb link: https://ui.honeycomb.io/test-team/environments/test-env/datasets/test-service/trace?trace_id=1234',
+    );
+  });
+
+  it('makes request and handles successful requests that return errors', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+    });
+
+    const exporter = configureConsoleTraceLinkExporter({
+      apiKey: apikey,
+      serviceName: 'test-service',
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.honeycomb.io/1/auth',
+      {
+        headers: {
+          'x-honeycomb-team': apikey,
+        },
+      },
+    );
+
+    // @ts-expect-error we only include the properties we need
+    const fakeSpan: ReadableSpan = {
+      spanContext: () => ({
+        traceId: '1234',
+        spanId: '1234',
+        traceFlags: 0,
+      }),
+    };
+
+    // wait for promises to resolve
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    await new Promise(process.nextTick);
+
+    // all of the fetch() promises have to resolve before we can export
+    exporter.export([fakeSpan], () => {});
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '@honeycombio/opentelemetry-web: 🔕 Failed to get proper auth response from Honeycomb. No local visualization available.',
+    );
+  });
+
+  it('makes request and handles failed requests', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce({});
+
+    const exporter = configureConsoleTraceLinkExporter({
+      apiKey: apikey,
+      serviceName: 'test-service',
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.honeycomb.io/1/auth',
+      {
+        headers: {
+          'x-honeycomb-team': apikey,
+        },
+      },
+    );
+
+    // @ts-expect-error we only include the properties we need
+    const fakeSpan: ReadableSpan = {
+      spanContext: () => ({
+        traceId: '1234',
+        spanId: '1234',
+        traceFlags: 0,
+      }),
+    };
+
+    // wait for promises to resolve
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    await new Promise(process.nextTick);
+
+    // all of the fetch() promises have to resolve before we can export
+    exporter.export([fakeSpan], () => {});
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '@honeycombio/opentelemetry-web: 🔕 Failed to get proper auth response from Honeycomb. No local visualization available.',
     );
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
Some users were unable to install this package due to issues with our transitive dependency on `axios`. 

It turns out, though, that we don't really need axios for much. This PR removes it.

## Short description of the changes
Drop axios, switch to standard `fetch` API

## How to verify that this has the expected result
- [x] unit tests pass
- [x] Install into test repo, confirm ConsoleTraceLinkExporter still does what we think it does