### PR TITLE
feat: Upgrade to web-vitals@4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The SDK adds these fields to all telemetry:
 | `page.hostname` | custom | per-span |   | `docs.honeycomb.io`   |
 | `screen.width` | custom | static | Total available screen width in pixels.   | `780`   |
 | `screen.height` | custom | static |  Total available screen height in pixels | `1000`   |
-| `screen.size` | custom | static |  `small` (less than 768px), `medium` (769px - 1024px) or `large` (greater than 1024px), `unknown` if the size is missing. | 
+| `screen.size` | custom | static |  `small` (less than 768px), `medium` (769px - 1024px) or `large` (greater than 1024px), `unknown` if the size is missing. |
 | `honeycomb.distro.version` | stable | static | package version | "1.2.3" |
 | `honeycomb.distro.runtime_version` | stable | static | | "browser" |
 | `entry_page.url`      | custom | static |   | `https://docs.honeycomb.io/getting-data-in/data-best-practices/#datasets-group-data-together?page=2` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@opentelemetry/semantic-conventions": "~1.24.0",
         "shimmer": "^1.2.1",
         "ua-parser-js": "^1.0.37",
-        "web-vitals": "^3.5.2"
+        "web-vitals": "^4.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",
@@ -7823,9 +7823,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
-      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.0.0.tgz",
+      "integrity": "sha512-8wQd4jkwFRwY5q3yAmHZAJ5MjnKR1vRACK+g2OEC8nUqi0WOxBrXfOxGNlJ+QtxzzSn/TkQO58wkW0coE68n0Q=="
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -13793,9 +13793,9 @@
       }
     },
     "web-vitals": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
-      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.0.0.tgz",
+      "integrity": "sha512-8wQd4jkwFRwY5q3yAmHZAJ5MjnKR1vRACK+g2OEC8nUqi0WOxBrXfOxGNlJ+QtxzzSn/TkQO58wkW0coE68n0Q=="
     },
     "webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "@opentelemetry/semantic-conventions": "~1.24.0",
     "shimmer": "^1.2.1",
     "ua-parser-js": "^1.0.37",
-    "web-vitals": "^3.5.2"
+    "web-vitals": "^4.0.0"
   }
 }

--- a/src/web-vitals-autoinstrumentation.ts
+++ b/src/web-vitals-autoinstrumentation.ts
@@ -338,7 +338,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       url,
       timeToFirstByte,
       resourceLoadDelay,
-      resourceLoadTime,
+      resourceLoadDuration,
       elementRenderDelay,
     }: LCPAttribution = attribution;
     const attrPrefix = this.getAttrPrefix(name);
@@ -350,7 +350,8 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.url`]: url,
       [`${attrPrefix}.time_to_first_byte`]: timeToFirstByte,
       [`${attrPrefix}.resource_load_delay`]: resourceLoadDelay,
-      [`${attrPrefix}.resource_load_time`]: resourceLoadTime,
+      [`${attrPrefix}.resource_load_duration`]: resourceLoadDuration,
+      // [`${attrPrefix}.resource_load_time`]: resourceLoadDuration, // TODO:  Deprecate instead?
       [`${attrPrefix}.element_render_delay`]: elementRenderDelay,
     });
 
@@ -368,16 +369,31 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
     if (!this.isEnabled()) return;
 
     const { name, attribution } = inp;
-    const { eventTarget, eventType, loadState }: INPAttribution = attribution;
+    const {
+      inputDelay,
+      interactionTarget,
+      interactionTime,
+      interactionType,
+      loadState,
+      nextPaintTime,
+      presentationDelay,
+      processingDuration,
+    }: INPAttribution = attribution;
     const attrPrefix = this.getAttrPrefix(name);
 
     const span = this.tracer.startSpan(name);
 
     span.setAttributes({
       ...this.getSharedAttributes(inp),
-      [`${attrPrefix}.element`]: eventTarget,
-      [`${attrPrefix}.event_type`]: eventType,
+      [`${attrPrefix}.input_delay`]: inputDelay,
+      [`${attrPrefix}.interaction_target`]: interactionTarget,
+      [`${attrPrefix}.interaction_time`]: interactionTime,
+      [`${attrPrefix}.interaction_type`]: interactionType,
       [`${attrPrefix}.load_state`]: loadState,
+      [`${attrPrefix}.next_paint_time`]: nextPaintTime,
+      [`${attrPrefix}.presentation_delay`]: presentationDelay,
+      [`${attrPrefix}.processing_duration`]: processingDuration,
+      // [`${attrPrefix}.event_type`]: interactionType, // TODO:  Deprecate instead?
     });
 
     if (applyCustomAttributes) {
@@ -448,10 +464,11 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
 
     const { name, attribution } = ttfb;
     const {
-      waitingTime,
-      dnsTime,
-      connectionTime,
-      requestTime,
+      cacheDuration,
+      connectionDuration,
+      dnsDuration,
+      requestDuration,
+      waitingDuration,
     }: TTFBAttribution = attribution;
     const attrPrefix = this.getAttrPrefix(name);
 
@@ -459,10 +476,15 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
 
     span.setAttributes({
       ...this.getSharedAttributes(ttfb),
-      [`${attrPrefix}.waiting_time`]: waitingTime,
-      [`${attrPrefix}.dns_time`]: dnsTime,
-      [`${attrPrefix}.connection_time`]: connectionTime,
-      [`${attrPrefix}.request_time`]: requestTime,
+      [`${attrPrefix}.waiting_duration`]: waitingDuration,
+      [`${attrPrefix}.dns_duration`]: dnsDuration,
+      [`${attrPrefix}.connection_duration`]: connectionDuration,
+      [`${attrPrefix}.request_duration`]: requestDuration,
+      [`${attrPrefix}.cache_duration`]: cacheDuration,
+      // [`${attrPrefix}.waiting_time`]: waitingDuration, // TODO:  Deprecate instead?
+      // [`${attrPrefix}.dns_time`]: dnsDuration,
+      // [`${attrPrefix}.connection_time`]: connectionDuration,
+      // [`${attrPrefix}.request_time`]: requestDuration,
     });
 
     if (applyCustomAttributes) {

--- a/src/web-vitals-autoinstrumentation.ts
+++ b/src/web-vitals-autoinstrumentation.ts
@@ -394,7 +394,8 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.next_paint_time`]: nextPaintTime,
       [`${attrPrefix}.presentation_delay`]: presentationDelay,
       [`${attrPrefix}.processing_duration`]: processingDuration,
-      // This will be deprecated in a future version
+      // These will be deprecated in a future version
+      [`${attrPrefix}.element`]: interactionTarget,
       [`${attrPrefix}.event_type`]: interactionType,
     });
 

--- a/src/web-vitals-autoinstrumentation.ts
+++ b/src/web-vitals-autoinstrumentation.ts
@@ -351,8 +351,9 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.time_to_first_byte`]: timeToFirstByte,
       [`${attrPrefix}.resource_load_delay`]: resourceLoadDelay,
       [`${attrPrefix}.resource_load_duration`]: resourceLoadDuration,
-      // [`${attrPrefix}.resource_load_time`]: resourceLoadDuration, // TODO:  Deprecate instead?
       [`${attrPrefix}.element_render_delay`]: elementRenderDelay,
+      // This will be deprecated in a future version
+      [`${attrPrefix}.resource_load_time`]: resourceLoadDuration,
     });
 
     if (applyCustomAttributes) {
@@ -393,7 +394,8 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.next_paint_time`]: nextPaintTime,
       [`${attrPrefix}.presentation_delay`]: presentationDelay,
       [`${attrPrefix}.processing_duration`]: processingDuration,
-      // [`${attrPrefix}.event_type`]: interactionType, // TODO:  Deprecate instead?
+      // This will be deprecated in a future version
+      [`${attrPrefix}.event_type`]: interactionType,
     });
 
     if (applyCustomAttributes) {
@@ -481,10 +483,11 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.connection_duration`]: connectionDuration,
       [`${attrPrefix}.request_duration`]: requestDuration,
       [`${attrPrefix}.cache_duration`]: cacheDuration,
-      // [`${attrPrefix}.waiting_time`]: waitingDuration, // TODO:  Deprecate instead?
-      // [`${attrPrefix}.dns_time`]: dnsDuration,
-      // [`${attrPrefix}.connection_time`]: connectionDuration,
-      // [`${attrPrefix}.request_time`]: requestDuration,
+      // These will be deprecated ina future version
+      [`${attrPrefix}.waiting_time`]: waitingDuration,
+      [`${attrPrefix}.dns_time`]: dnsDuration,
+      [`${attrPrefix}.connection_time`]: connectionDuration,
+      [`${attrPrefix}.request_time`]: requestDuration,
     });
 
     if (applyCustomAttributes) {

--- a/src/web-vitals-autoinstrumentation.ts
+++ b/src/web-vitals-autoinstrumentation.ts
@@ -433,6 +433,9 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
     span.end();
   };
 
+  /**
+   *  @deprecated this will be removed in the next major version, use INP instead.
+   */
   onReportFID = (
     fid: FIDMetricWithAttribution,
     applyCustomAttributes?: ApplyCustomAttributesFn,

--- a/test/web-vitals-instrumentation.test.ts
+++ b/test/web-vitals-instrumentation.test.ts
@@ -69,7 +69,7 @@ const LCP: LCPMetricWithAttribution = {
     element: 'div#lcp-element',
     url: 'https://my-cool-image.stuff',
     timeToFirstByte: 30,
-    resourceLoadTime: 20,
+    resourceLoadDuration: 20,
     elementRenderDelay: 20,
     resourceLoadDelay: 100,
   },
@@ -85,7 +85,7 @@ const LCPAttr = {
   'lcp.url': 'https://my-cool-image.stuff',
   'lcp.time_to_first_byte': 30,
   'lcp.resource_load_delay': 100,
-  'lcp.resource_load_time': 20,
+  'lcp.resource_load_duration': 20,
   'lcp.element_render_delay': 20,
   'lcp.entries': '',
   'lcp.my_custom_attr': 'custom_attr',
@@ -100,9 +100,17 @@ const INP: INPMetricWithAttribution = {
   entries: [],
   navigationType: 'back-forward',
   attribution: {
-    eventTarget: 'div#inp-element',
-    eventType: 'input-delay',
+    interactionTarget: 'div#inp-element',
+    interactionType: 'pointer',
     loadState: 'complete',
+    interactionTargetElement: undefined,
+    interactionTime: 10,
+    nextPaintTime: 400,
+    processedEventEntries: [],
+    longAnimationFrameEntries: [],
+    inputDelay: 42,
+    processingDuration: 600,
+    presentationDelay: 500,
   },
 };
 
@@ -112,11 +120,16 @@ const INPAttr = {
   'inp.delta': 200,
   'inp.rating': 'good',
   'inp.navigation_type': 'back-forward',
-  'inp.element': 'div#inp-element',
-  'inp.event_type': 'input-delay',
+  'inp.interaction_target': 'div#inp-element',
+  'inp.interaction_type': 'pointer',
   'inp.load_state': 'complete',
   'inp.entries': '',
   'inp.my_custom_attr': 'custom_attr',
+  'inp.next_paint_time': 400,
+  'inp.presentation_delay': 500,
+  'inp.processing_duration': 600,
+  'inp.interaction_time': 10,
+  'inp.input_delay': 42,
 };
 
 const FCP: FCPMetricWithAttribution = {
@@ -156,10 +169,11 @@ const TTFB: TTFBMetricWithAttribution = {
   navigationType: 'back-forward',
   entries: [],
   attribution: {
-    waitingTime: 100,
-    dnsTime: 1000,
-    connectionTime: 200,
-    requestTime: 300,
+    waitingDuration: 100,
+    dnsDuration: 1000,
+    requestDuration: 300,
+    cacheDuration: 100,
+    connectionDuration: 200,
   },
 };
 
@@ -169,10 +183,11 @@ const TTFBAttr = {
   'ttfb.delta': 2500,
   'ttfb.rating': 'good',
   'ttfb.navigation_type': 'back-forward',
-  'ttfb.waiting_time': 100,
-  'ttfb.dns_time': 1000,
-  'ttfb.connection_time': 200,
-  'ttfb.request_time': 300,
+  'ttfb.waiting_duration': 100,
+  'ttfb.dns_duration': 1000,
+  'ttfb.connection_duration': 200,
+  'ttfb.cache_duration': 100,
+  'ttfb.request_duration': 300,
   'ttfb.entries': '',
   'ttfb.my_custom_attr': 'custom_attr',
 };
@@ -201,6 +216,8 @@ const FID: FIDMetricWithAttribution = {
       toJSON() {
         return '';
       },
+      processingEnd: 600,
+      interactionId: 42,
     },
   },
 };

--- a/test/web-vitals-instrumentation.test.ts
+++ b/test/web-vitals-instrumentation.test.ts
@@ -89,6 +89,7 @@ const LCPAttr = {
   'lcp.element_render_delay': 20,
   'lcp.entries': '',
   'lcp.my_custom_attr': 'custom_attr',
+  'lcp.resource_load_time': 20,
 };
 
 const INP: INPMetricWithAttribution = {
@@ -130,6 +131,7 @@ const INPAttr = {
   'inp.processing_duration': 600,
   'inp.interaction_time': 10,
   'inp.input_delay': 42,
+  'inp.event_type': 'pointer',
 };
 
 const FCP: FCPMetricWithAttribution = {
@@ -190,6 +192,10 @@ const TTFBAttr = {
   'ttfb.request_duration': 300,
   'ttfb.entries': '',
   'ttfb.my_custom_attr': 'custom_attr',
+  'ttfb.waiting_time': 100,
+  'ttfb.connection_time': 200,
+  'ttfb.dns_time': 1000,
+  'ttfb.request_time': 300,
 };
 
 const FID: FIDMetricWithAttribution = {

--- a/test/web-vitals-instrumentation.test.ts
+++ b/test/web-vitals-instrumentation.test.ts
@@ -131,6 +131,7 @@ const INPAttr = {
   'inp.processing_duration': 600,
   'inp.interaction_time': 10,
   'inp.input_delay': 42,
+  'inp.element': 'div#inp-element',
   'inp.event_type': 'pointer',
 };
 


### PR DESCRIPTION
## Which problem is this PR solving?
Web vitals but released 4.0.0 which includes an updates to field names and additional for `LCPAttribution`, `INPAttribution` and `TTFBAttribution` and deprecated `onFID`. See the full changes [here](https://github.com/GoogleChrome/web-vitals/blob/v4.0.0/docs/upgrading-to-v4.md).

## Short description of the changes
Upgrade to `web-vitals@4.0.0`. Full change log of the underlying changes can be found [here](https://github.com/GoogleChrome/web-vitals/blob/v4.0.0/docs/upgrading-to-v4.md).

For this release, we'll send both the updated field names and the deprecated field names, which will be removed in the next major release.
Additionally, `onFID` has been deprecated and will removed in the next major release.

For this instrumentation we have updated attribute payloads as follows:

### `LCP`:
- Updated `resource_load_time` -> `resource_load_duration`
- Deprecated `resource_load_time`

### `INP`:
- Updated `element` -> `interaction_target`
- Deprecated `element`
- Updated `event_type` -> `interaction_type`
- Deprecated `event_type`
- Added `interaction_time` 
- Added `input_delay`
- Added `interaction_target_element`
- Added `next_paint_time`
- Added `presentation_delay`
- Added `processing_duration`

### `TTFB`:
- Updated `waiting_time` -> `waiting_duration`
- Deprecated `waiting_time`
- Updated `dns_time` -> `dns_duration`
- Deprecated `dns_time`
- Updated `connection_time` -> `connection_duration`
- Deprecated `connection_time`
- Updated `request_time` -> `request_duration`
- Deprecated `request_time`
- Added `cache_duration`

## How to verify that this has the expected result
See that the new new and updated properties are being reported. 