### PR TITLE
fix: Use constant for `service.name` from semconv library

### DIFF
--- a/src/base-otel-sdk.ts
+++ b/src/base-otel-sdk.ts
@@ -38,7 +38,7 @@ import {
   WebTracerConfig,
   WebTracerProvider,
 } from '@opentelemetry/sdk-trace-web';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { WebSDKConfiguration } from './types';
 import { SessionIdSpanProcessor } from './session-id-span-processor';
 import { browserDetector } from '@opentelemetry/opentelemetry-browser-detector';
@@ -135,7 +135,7 @@ export class WebSDK {
         ? this._resource
         : this._resource.merge(
             new Resource({
-              [SemanticResourceAttributes.SERVICE_NAME]: this._serviceName,
+              [SEMRESATTRS_SERVICE_NAME]: this._serviceName,
             }),
           );
 


### PR DESCRIPTION
## Which problem is this PR solving?
While doing some bundle size analysis, noticed that the `@opentelemetry/semantic-conventions` library is a significant contributor to the bundle size because it has a lot of unminified constants. There was a [PR merged that also exports each constant by itself](https://github.com/open-telemetry/opentelemetry-js/pull/4298) instead of on an object which allows tree shaking to only import that constant instead of a whole object. This PR uses the new constants from the `@opentelemetry/semantic-conventions` instead of the deprecated `SemanticConventions` object.

## Short description of the changes
- Use exported constant for service name.

## How to verify that this has the expected result
- Smoke tests pass
- Service name is still respected, run the example app locally and check that service name is set to the value expected.
