### PR TITLE
docs: add example config & API calls for network events

### DIFF
--- a/examples/custom-with-collector-ts/package-lock.json
+++ b/examples/custom-with-collector-ts/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@honeycombio/opentelemetry-web": "file:../../",
-        "@opentelemetry/auto-instrumentations-web": "~0.36.0"
+        "@opentelemetry/auto-instrumentations-web": "^0.40.0"
       },
       "devDependencies": {
         "html-webpack-plugin": "^5.5.4",
@@ -23,30 +23,33 @@
     },
     "../..": {
       "name": "@honeycombio/opentelemetry-web",
-      "version": "0.0.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api": "~1.7.0",
-        "@opentelemetry/exporter-trace-otlp-http": "~0.48.0",
-        "@opentelemetry/instrumentation": "~0.48.0",
-        "@opentelemetry/opentelemetry-browser-detector": "~0.48.0",
-        "@opentelemetry/resources": "~1.21.0",
-        "@opentelemetry/sdk-trace-base": "~1.21.0",
-        "@opentelemetry/sdk-trace-web": "~1.21.0",
-        "@opentelemetry/semantic-conventions": "~1.21.0",
-        "@typescript-eslint/eslint-plugin": "^7.0.2",
-        "@typescript-eslint/parser": "^7.0.2",
-        "axios": "^1.6.7",
-        "eslint-config-prettier": "^9.1.0",
-        "prettier": "^3.2.4",
-        "web-vitals": "^3.5.2"
+        "@opentelemetry/api": "~1.8.0",
+        "@opentelemetry/core": "~1.24.0",
+        "@opentelemetry/exporter-trace-otlp-http": "~0.51.0",
+        "@opentelemetry/instrumentation": "~0.51.0",
+        "@opentelemetry/opentelemetry-browser-detector": "~0.51.0",
+        "@opentelemetry/resources": "~1.24.0",
+        "@opentelemetry/sdk-trace-base": "~1.24.0",
+        "@opentelemetry/sdk-trace-web": "~1.24.0",
+        "@opentelemetry/semantic-conventions": "~1.24.0",
+        "shimmer": "^1.2.1",
+        "ua-parser-js": "^1.0.37",
+        "web-vitals": "^4.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",
+        "@types/ua-parser-js": "^0.7.39",
+        "@typescript-eslint/eslint-plugin": "^7.0.2",
+        "@typescript-eslint/parser": "^7.0.2",
         "cypress": "^13.6.4",
+        "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "prettier": "^3.2.4",
         "ts-jest": "^29.1.2",
         "typescript": "^5.3.3"
       }
@@ -132,54 +135,65 @@
       "dev": true
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
-      "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
-      "peer": true,
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/auto-instrumentations-web": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-web/-/auto-instrumentations-web-0.36.0.tgz",
-      "integrity": "sha512-OwUmX3XBaky93dnFGiFg23H9Nwp1ofkigUXzI1iTDEDCMJDX3HeBx0M83YoZUPFA1lRK6vajMy+sdVdE+IkO+A==",
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
+      "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.48.0",
-        "@opentelemetry/instrumentation-document-load": "^0.35.0",
-        "@opentelemetry/instrumentation-fetch": "^0.48.0",
-        "@opentelemetry/instrumentation-user-interaction": "^0.35.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.48.0"
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/auto-instrumentations-web": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-web/-/auto-instrumentations-web-0.40.0.tgz",
+      "integrity": "sha512-WaeIjd9HyK+cGitynZrDocIqLnNQj1NrBwo5R3z/xHW+oYhkBpo8GwuvdSZW7erVqqPcRntHQt+IF+eUi9Tylw==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation-document-load": "^0.39.0",
+        "@opentelemetry/instrumentation-fetch": "^0.52.0",
+        "@opentelemetry/instrumentation-user-interaction": "^0.39.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.52.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "zone.js": "0.11.4"
+        "zone.js": "^0.11.4 || ^0.13.0 || ^0.14.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.21.0.tgz",
-      "integrity": "sha512-KP+OIweb3wYoP7qTYL/j5IpOlu52uxBv5M4+QhSmmUfLyTgu1OIS71msK3chFo1D6Y61BIH3wMiMYRCxJCQctA==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.0.tgz",
+      "integrity": "sha512-n0B3s8rrqGrasTgNkXLKXzN0fXo+6IYP7M5b7AMsrZM33f/y6DS6kJ0Btd7SespASWq8bgL3taLo0oe0vB52IQ==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.48.0.tgz",
-      "integrity": "sha512-sjtZQB5PStIdCw5ovVTDGwnmQC+GGYArJNgIcydrDSqUTdYBnMrN9P4pwQZgS3vTGIp+TU1L8vMXGe51NVmIKQ==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.0.tgz",
+      "integrity": "sha512-LPwSIrw+60cheWaXsfGL8stBap/AppKQJFE+qqRvzYrgttXFH2ofoIMxWadeqPTq4BYOXM/C7Bdh/T+B60xnlQ==",
       "dependencies": {
+        "@opentelemetry/api-logs": "0.52.0",
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.1",
+        "import-in-the-middle": "1.8.0",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -192,15 +206,15 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-document-load": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-document-load/-/instrumentation-document-load-0.35.0.tgz",
-      "integrity": "sha512-U3zQBjbAF0rm7GT7YJ8DPqgiCdBoshmld4c1pZe3tAGAMa5QPIjonIfSMSvJ2XMh6Nvi+8Rfe3XFCe0cuWIjsQ==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-document-load/-/instrumentation-document-load-0.39.0.tgz",
+      "integrity": "sha512-M8QTHM1fFoJvQ1EYaxAF7V5RJhG4c+o4gWHLSFQl6dvQJuGiSdhM3azenRFcTe88Sn6AmVYRGiUjlac9GSVQ2g==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -210,14 +224,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fetch": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.48.0.tgz",
-      "integrity": "sha512-y4Zw9VeUUMaowg3aXYZXcaUJQ7IKfpR6sjClrAQOJwWG8LYFpM6NIRSoAeJv/ShfxWWCPWC0P4zgXcKRqpURFQ==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.52.0.tgz",
+      "integrity": "sha512-ay1Ot0z/586MBnhZnWJJFWXjBCQjddVVjCxLPRECnorhzmXuOsjUb7zTY88Vv9ddRtcHe0EIp9Z8sWQeLT02kA==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/sdk-trace-web": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
@@ -227,12 +241,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-user-interaction": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-user-interaction/-/instrumentation-user-interaction-0.35.0.tgz",
-      "integrity": "sha512-d66rqb24onIEnFNxXorCEzj+5tYBJKM/6StRl+SKXfRDXRT+nBj5EGdBUNgk+jiGQ0M/RymZHHHXSguTV2F1fA==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-user-interaction/-/instrumentation-user-interaction-0.39.0.tgz",
+      "integrity": "sha512-hO/D1g8/P1fo5lEEHpxHHnxXDRfysjBZdFGwR6oSIoZWAQW1EasxZRe2mYDnxc37vEZsFFxTWXayH+XMKOo/sw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0"
       },
       "engines": {
@@ -240,18 +254,18 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "zone.js": "0.11.4"
+        "zone.js": "^0.11.4 || ^0.13.0 || ^0.14.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.48.0.tgz",
-      "integrity": "sha512-YJ9d1sR28hcEVtP4/tHtPX5Hhu0w2LsAMp3M+75YGTHkkunsN8PwcY/1FcSHUP9xwy7Z2myQvT7fTpL3g4tn4A==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.52.0.tgz",
+      "integrity": "sha512-Q6dEFKBkVmLs6XByXNPkCZXYF1Ovs3fFCD33nA4d4dgBgv8zMPt7xBLIxfEw0QVDZhyBhKXwv7byvMDB+yYQdA==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/sdk-trace-web": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
@@ -261,56 +275,56 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.21.0.tgz",
-      "integrity": "sha512-1Z86FUxPKL6zWVy2LdhueEGl9AHDJcx+bvHStxomruz6Whd02mE3lNUMjVJ+FGRoktx/xYQcxccYb03DiUP6Yw==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.0.tgz",
+      "integrity": "sha512-iHjydPMYJ+Li1auveJCq2rp5U2h6Mhq8BidiyE0jfVlDTFyR1ny8AfJHfmFzJ/RAM8vT8L7T21kcmGybxZC7lQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.21.0.tgz",
-      "integrity": "sha512-yrElGX5Fv0umzp8Nxpta/XqU71+jCAyaLk34GmBzNcrW43nqbrqvdPs4gj4MVy/HcTjr6hifCDCYA3rMkajxxA==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.0.tgz",
+      "integrity": "sha512-6+g2fiRQUG39guCsKVeY8ToeuUf3YUnPkN6DXRA1qDmFLprlLvZm9cS6+chgbW70cZJ406FTtSCDnJwxDC5sGQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.21.0.tgz",
-      "integrity": "sha512-MxkmY/UNXkDiZj7JUu5T7wWt8Ai4NJEwSjGoQQ9YLvgLUIivvaIo9Mne+Q+KLOUG2v/uhivz3qzxbCODVa0c1A==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.25.0.tgz",
+      "integrity": "sha512-TAWRDRiVOeliE1A99z8idWb4pwEKKY9Vj5aTpLtrF4cvPOl0mPg3ZczvOw/HnpfRsWY0Ra/J3vS5uFSpoqPwEA==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.21.0.tgz",
-      "integrity": "sha512-lkC8kZYntxVKr7b8xmjCVUgE0a8xgDakPyDo9uSWavXPyYqLgYYGdEd2j8NxihRyb6UwpX3G/hFUF4/9q2V+/g==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ==",
       "engines": {
         "node": ">=14"
       }
@@ -755,6 +769,15 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -1131,9 +1154,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
+      "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q=="
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
@@ -2316,12 +2339,12 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.8.0.tgz",
+      "integrity": "sha512-/xQjze8szLNnJ5rvHSzn+dcVXqCAU6Plbk4P24U/jwPmg1wy7IIp9OjKIO5tYue8GSPhDpPDiApQjvBUmWwhsQ==",
       "dependencies": {
         "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
@@ -3231,9 +3254,9 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
-      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.3.0.tgz",
+      "integrity": "sha512-nQFEv9gRw6SJAwWD2LrL0NmQvAcO7FBwJbwmr2ttPAacfy0xuiOjE5zt+zM4xDyuyvUaxBi/9gb2SoCyNEVJcw==",
       "dependencies": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
@@ -3870,7 +3893,8 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4402,13 +4426,10 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/zone.js": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.4.tgz",
-      "integrity": "sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      }
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.6.tgz",
+      "integrity": "sha512-vyRNFqofdaHVdWAy7v3Bzmn84a1JHWSjpuTZROT/uYn8I3p2cmo7Ro9twFmYRQDPhiYOV7QLk0hhY4JJQVqS6Q==",
+      "peer": true
     }
   }
 }

--- a/examples/custom-with-collector-ts/package-lock.json
+++ b/examples/custom-with-collector-ts/package-lock.json
@@ -135,9 +135,9 @@
       "dev": true
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4426,9 +4426,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/zone.js": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.6.tgz",
-      "integrity": "sha512-vyRNFqofdaHVdWAy7v3Bzmn84a1JHWSjpuTZROT/uYn8I3p2cmo7Ro9twFmYRQDPhiYOV7QLk0hhY4JJQVqS6Q==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.7.tgz",
+      "integrity": "sha512-0w6DGkX2BPuiK/NLf+4A8FLE43QwBfuqz2dVgi/40Rj1WmqUskCqj329O/pwrqFJLG5X8wkeG2RhIAro441xtg==",
       "peer": true
     }
   }

--- a/examples/custom-with-collector-ts/package.json
+++ b/examples/custom-with-collector-ts/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@honeycombio/opentelemetry-web": "file:../../",
-    "@opentelemetry/auto-instrumentations-web": "~0.36.0"
+    "@opentelemetry/auto-instrumentations-web": "^0.40.0"
   },
   "devDependencies": {
     "html-webpack-plugin": "^5.5.4",

--- a/examples/custom-with-collector-ts/src/index.html
+++ b/examples/custom-with-collector-ts/src/index.html
@@ -13,6 +13,11 @@
       <h1>Example app sending to a collector</h1>
     </header>
     <button id="button-important" data-cy="button">click me!</button>
+
+    <button id="loadDadJoke">Get A Random Dad Joke</button>
+    <div>
+      <span id="dadJokeText"></span>
+    </div>
   </section>
   <!-- Scripts here. Don't remove ↓ -->
   <script type="module" src="dist/index.js"></script>

--- a/examples/custom-with-collector-ts/src/index.ts
+++ b/examples/custom-with-collector-ts/src/index.ts
@@ -3,6 +3,10 @@ import { HoneycombWebSDK } from '@honeycombio/opentelemetry-web';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 
 const tracing = () => {
+  const configDefaults = {
+    ignoreNetworkEvents: true,
+  };
+
   const sdk = new HoneycombWebSDK({
     // To send direct to Honeycomb, set API Key and comment out endpoint
     // apiKey: 'api-key',
@@ -11,7 +15,15 @@ const tracing = () => {
     debug: true,
     skipOptionsValidation: true,
     resourceAttributes: { 'app.environment': 'development' },
-    instrumentations: [getWebAutoInstrumentations()], // add auto-instrumentation
+    instrumentations: [
+      // add auto-instrumentation
+      getWebAutoInstrumentations({
+        // load custom configuration for xml-http-request instrumentation
+        '@opentelemetry/instrumentation-xml-http-request': configDefaults,
+        '@opentelemetry/instrumentation-fetch': configDefaults,
+        '@opentelemetry/instrumentation-document-load': configDefaults,
+      }),
+    ],
   });
   sdk.start();
 };
@@ -50,8 +62,29 @@ const onClick = () => {
   });
 };
 
+const setupAPICall = () => {
+  document.getElementById('loadDadJoke')!.onclick = () => {
+    fetch('https://icanhazdadjoke.com/', {
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json',
+      },
+    })
+      .then((res) => {
+        return res.json();
+      })
+      .then((data) => {
+        document.getElementById('dadJokeText')!.innerText = data.joke;
+      })
+      .catch((e) => {
+        console.error(e);
+      });
+  };
+};
+
 const main = () => {
   tracing();
   trackButton(onClick);
+  setupAPICall();
 };
 main();

--- a/examples/custom-with-collector-ts/src/index.ts
+++ b/examples/custom-with-collector-ts/src/index.ts
@@ -18,7 +18,6 @@ const tracing = () => {
     instrumentations: [
       // add auto-instrumentation
       getWebAutoInstrumentations({
-        // load custom configuration for xml-http-request instrumentation
         '@opentelemetry/instrumentation-xml-http-request': configDefaults,
         '@opentelemetry/instrumentation-fetch': configDefaults,
         '@opentelemetry/instrumentation-document-load': configDefaults,
@@ -32,13 +31,14 @@ const trackButton = (onClick: { (): void; (): void }) => {
   const button = document.getElementById(
     'button-important',
   ) as HTMLButtonElement;
-  const tracer = trace.getTracer('click-tracer');
 
-  button.onclick = () =>
-    tracer.startActiveSpan(`clicked the button`, (span) => {
+  button.onclick = () => {
+    const tracer = trace.getTracer('click-tracer');
+    return tracer.startActiveSpan(`clicked the button`, (span) => {
       onClick();
       span.end();
     });
+  };
 };
 
 const onClick = () => {

--- a/examples/custom-with-collector-ts/webpack.config.js
+++ b/examples/custom-with-collector-ts/webpack.config.js
@@ -42,4 +42,5 @@ export default {
     compress: true,
     host: '0.0.0.0',
   },
+  devtool: 'eval-source-map',
 };

--- a/examples/hello-world-web/index.html
+++ b/examples/hello-world-web/index.html
@@ -11,6 +11,11 @@
 			<header class="header">
 				<h1>👋 Hello World</h1>
 			</header>
+
+			<button id="loadDadJoke">Get A Random Dad Joke</button>
+			<div>
+				<span id="dadJokeText"></span>
+			</div>
 		</section>
 		<!-- Scripts here. Don't remove ↓ -->
 		<script type="module" src="build/bundle.js"></script>

--- a/examples/hello-world-web/index.js
+++ b/examples/hello-world-web/index.js
@@ -1,20 +1,47 @@
 import { HoneycombWebSDK } from '@honeycombio/opentelemetry-web';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 
+const configDefaults = {
+  ignoreNetworkEvents: true,
+};
+
 const main = () => {
-  // Initialize base OTel WebSDK
+  // Initialize Honeycomb SDK
   const sdk = new HoneycombWebSDK({
-    // endpoint: 'http://localhost:4318', // send to collector
-    // To send to collector, comment out API Key
-    apiKey: 'api-key',
-    serviceName: 'web-distro',
+    // defaults to sending to US instance of Honeycomb
+    // endpoint: "https://api.eu1.honeycomb.io/v1/traces", // uncomment to send to EU instance
+    apiKey: 'api-key', // Replace with your Honeycomb Ingest API Key
+    serviceName: 'web-distro', // Replace with your application name. Honeycomb will name your dataset using this variable.
     debug: true,
-    instrumentations: [getWebAutoInstrumentations()], // add auto-instrumentation
-    // webVitalsInstrumentationConfig: {
-    //   enabled: false,
-    // },
+    instrumentations: [
+      getWebAutoInstrumentations({
+        // load custom configuration for xml-http-request instrumentation
+        '@opentelemetry/instrumentation-xml-http-request': configDefaults,
+        '@opentelemetry/instrumentation-fetch': configDefaults,
+        '@opentelemetry/instrumentation-document-load': configDefaults,
+      }),
+    ],
   });
   sdk.start();
+
+  // add event handlers
+  document.getElementById('loadDadJoke').onclick = () => {
+    fetch('https://icanhazdadjoke.com/', {
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json',
+      },
+    })
+      .then((res) => {
+        return res.json();
+      })
+      .then((data) => {
+        document.getElementById('dadJokeText').innerText = data.joke;
+      })
+      .catch((e) => {
+        console.error(e);
+      });
+  };
 };
 
 main();

--- a/examples/hello-world-web/package-lock.json
+++ b/examples/hello-world-web/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@honeycombio/opentelemetry-web": "file:../../dist/src",
-        "@opentelemetry/auto-instrumentations-web": "~0.39.0"
+        "@opentelemetry/auto-instrumentations-web": "^0.40.0"
       },
       "devDependencies": {
         "chokidar": "^3.6.0",
@@ -396,17 +396,17 @@
       "link": true
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
-      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.0.tgz",
-      "integrity": "sha512-m/jtfBPEIXS1asltl8fPQtO3Sb1qMpuL61unQajUmM8zIxeMF1AlqzWXM3QedcYgTTFiJCew5uJjyhpmqhc0+g==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
+      "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -415,15 +415,15 @@
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-web": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-web/-/auto-instrumentations-web-0.39.0.tgz",
-      "integrity": "sha512-RnN2NdWASajyRmErDk/8aMfSb6Vyphpg1bc7j+5Hz0+XrlokmniTyaQT04z6AU8EYLX06dM26r56/RhUV6yNJQ==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-web/-/auto-instrumentations-web-0.40.0.tgz",
+      "integrity": "sha512-WaeIjd9HyK+cGitynZrDocIqLnNQj1NrBwo5R3z/xHW+oYhkBpo8GwuvdSZW7erVqqPcRntHQt+IF+eUi9Tylw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/instrumentation-document-load": "^0.38.0",
-        "@opentelemetry/instrumentation-fetch": "^0.51.0",
-        "@opentelemetry/instrumentation-user-interaction": "^0.38.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.51.0"
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation-document-load": "^0.39.0",
+        "@opentelemetry/instrumentation-fetch": "^0.52.0",
+        "@opentelemetry/instrumentation-user-interaction": "^0.39.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.52.0"
       },
       "engines": {
         "node": ">=14"
@@ -434,27 +434,27 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.0.tgz",
-      "integrity": "sha512-FP2oN7mVPqcdxJDTTnKExj4mi91EH+DNuArKfHTjPuJWe2K1JfMIVXNfahw1h3onJxQnxS8K0stKkogX05s+Aw==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.0.tgz",
+      "integrity": "sha512-n0B3s8rrqGrasTgNkXLKXzN0fXo+6IYP7M5b7AMsrZM33f/y6DS6kJ0Btd7SespASWq8bgL3taLo0oe0vB52IQ==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.0.tgz",
-      "integrity": "sha512-Eg/+Od5bEvzpvZQGhvMyKIkrzB9S7jW+6z9LHEI2VXhl/GrqQ3oBqlzJt4tA6pGtxRmqQWKWGM1wAbwDdW/gUA==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.0.tgz",
+      "integrity": "sha512-LPwSIrw+60cheWaXsfGL8stBap/AppKQJFE+qqRvzYrgttXFH2ofoIMxWadeqPTq4BYOXM/C7Bdh/T+B60xnlQ==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.0",
+        "@opentelemetry/api-logs": "0.52.0",
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.1",
+        "import-in-the-middle": "1.8.0",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -467,12 +467,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-document-load": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-document-load/-/instrumentation-document-load-0.38.0.tgz",
-      "integrity": "sha512-X/AOG8sDcVp/bVGRWDDG7MCRjcmuQwZqG2B2C6/oj8V4koXPNRNDvW2GEIGJhF5/WxJxZsTRIGPG+yeJ52QOww==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-document-load/-/instrumentation-document-load-0.39.0.tgz",
+      "integrity": "sha512-M8QTHM1fFoJvQ1EYaxAF7V5RJhG4c+o4gWHLSFQl6dvQJuGiSdhM3azenRFcTe88Sn6AmVYRGiUjlac9GSVQ2g==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
@@ -485,14 +485,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fetch": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.51.0.tgz",
-      "integrity": "sha512-dB9wisB2+wyh0wUB1RFNinCS4TqJ7QMVc4jNzy3JCMJudwFWI/stU10DgZ3vwFQNUEBUIz9QmEQSFud7lsvB2w==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.52.0.tgz",
+      "integrity": "sha512-ay1Ot0z/586MBnhZnWJJFWXjBCQjddVVjCxLPRECnorhzmXuOsjUb7zTY88Vv9ddRtcHe0EIp9Z8sWQeLT02kA==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/sdk-trace-web": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
@@ -502,12 +502,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-user-interaction": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-user-interaction/-/instrumentation-user-interaction-0.38.0.tgz",
-      "integrity": "sha512-/UZT7zZUpi3WavRW6GmxKSa3d3PQ1ApM9nG9PKq95d4w/zhXBaYiqGT/wzcyXefW4TL2oAq4sjJvt1rZpOlImA==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-user-interaction/-/instrumentation-user-interaction-0.39.0.tgz",
+      "integrity": "sha512-hO/D1g8/P1fo5lEEHpxHHnxXDRfysjBZdFGwR6oSIoZWAQW1EasxZRe2mYDnxc37vEZsFFxTWXayH+XMKOo/sw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0"
       },
       "engines": {
@@ -519,14 +519,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.51.0.tgz",
-      "integrity": "sha512-KgLO2qx1z1Wn9NeJgrgNukd10ssK1QqxODwdeBJFO1BaP9sVVargpupYowlDKUL5I3oWOEqi/Oxxdh/fbEsJtw==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.52.0.tgz",
+      "integrity": "sha512-Q6dEFKBkVmLs6XByXNPkCZXYF1Ovs3fFCD33nA4d4dgBgv8zMPt7xBLIxfEw0QVDZhyBhKXwv7byvMDB+yYQdA==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/sdk-trace-web": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
@@ -536,56 +536,56 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.0.tgz",
-      "integrity": "sha512-mxC7E7ocUS1tLzepnA7O9/G8G6ZTdjCH2pXme1DDDuCuk6n2/53GADX+GWBuyX0dfIxeMInIbJAdjlfN9GNr6A==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.0.tgz",
+      "integrity": "sha512-iHjydPMYJ+Li1auveJCq2rp5U2h6Mhq8BidiyE0jfVlDTFyR1ny8AfJHfmFzJ/RAM8vT8L7T21kcmGybxZC7lQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.0.tgz",
-      "integrity": "sha512-H9sLETZ4jw9UJ3totV8oM5R0m4CW0ZIOLfp4NV3g0CM8HD5zGZcaW88xqzWDgiYRpctFxd+WmHtGX/Upoa2vRg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.0.tgz",
+      "integrity": "sha512-6+g2fiRQUG39guCsKVeY8ToeuUf3YUnPkN6DXRA1qDmFLprlLvZm9cS6+chgbW70cZJ406FTtSCDnJwxDC5sGQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.24.0.tgz",
-      "integrity": "sha512-G0q8aZPUhRtO/iw2BkjHeNqCMBf0JQX5VqqiPWXn9u5iRkpeQ6LZrGaiymKWOdEqtXCgM44yrCY/4WoJqR0bjQ==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.25.0.tgz",
+      "integrity": "sha512-TAWRDRiVOeliE1A99z8idWb4pwEKKY9Vj5aTpLtrF4cvPOl0mPg3ZczvOw/HnpfRsWY0Ra/J3vS5uFSpoqPwEA==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.0.tgz",
-      "integrity": "sha512-yL0jI6Ltuz8R+Opj7jClGrul6pOoYrdfVmzQS4SITXRPH7I5IRZbrwe/6/v8v4WYMa6MYZG480S1+uc/IGfqsA==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ==",
       "engines": {
         "node": ">=14"
       }
@@ -625,10 +625,10 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -1379,12 +1379,12 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.8.0.tgz",
+      "integrity": "sha512-/xQjze8szLNnJ5rvHSzn+dcVXqCAU6Plbk4P24U/jwPmg1wy7IIp9OjKIO5tYue8GSPhDpPDiApQjvBUmWwhsQ==",
       "dependencies": {
         "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
@@ -1544,17 +1544,6 @@
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "dev": true
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -1857,9 +1846,9 @@
       }
     },
     "node_modules/require-in-the-middle/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1906,12 +1895,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2104,12 +2090,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "peer": true
-    },
     "node_modules/type-fest": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
@@ -2218,11 +2198,6 @@
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/yargs": {
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
@@ -2311,13 +2286,10 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.4.tgz",
-      "integrity": "sha512-NtTUvIlNELez7Q1DzKVIFZBzNb646boQMgpATo9z3Ftuu/gWvzxCW7jdjcUDoRGxRikrhVHB/zLXh1hxeJawvw==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      }
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.6.tgz",
+      "integrity": "sha512-vyRNFqofdaHVdWAy7v3Bzmn84a1JHWSjpuTZROT/uYn8I3p2cmo7Ro9twFmYRQDPhiYOV7QLk0hhY4JJQVqS6Q==",
+      "peer": true
     }
   },
   "dependencies": {
@@ -2486,128 +2458,128 @@
       "version": "file:../../dist/src"
     },
     "@opentelemetry/api": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
-      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/api-logs": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.0.tgz",
-      "integrity": "sha512-m/jtfBPEIXS1asltl8fPQtO3Sb1qMpuL61unQajUmM8zIxeMF1AlqzWXM3QedcYgTTFiJCew5uJjyhpmqhc0+g==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
+      "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
       "requires": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "@opentelemetry/auto-instrumentations-web": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-web/-/auto-instrumentations-web-0.39.0.tgz",
-      "integrity": "sha512-RnN2NdWASajyRmErDk/8aMfSb6Vyphpg1bc7j+5Hz0+XrlokmniTyaQT04z6AU8EYLX06dM26r56/RhUV6yNJQ==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-web/-/auto-instrumentations-web-0.40.0.tgz",
+      "integrity": "sha512-WaeIjd9HyK+cGitynZrDocIqLnNQj1NrBwo5R3z/xHW+oYhkBpo8GwuvdSZW7erVqqPcRntHQt+IF+eUi9Tylw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.51.0",
-        "@opentelemetry/instrumentation-document-load": "^0.38.0",
-        "@opentelemetry/instrumentation-fetch": "^0.51.0",
-        "@opentelemetry/instrumentation-user-interaction": "^0.38.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.51.0"
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation-document-load": "^0.39.0",
+        "@opentelemetry/instrumentation-fetch": "^0.52.0",
+        "@opentelemetry/instrumentation-user-interaction": "^0.39.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.52.0"
       }
     },
     "@opentelemetry/core": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.0.tgz",
-      "integrity": "sha512-FP2oN7mVPqcdxJDTTnKExj4mi91EH+DNuArKfHTjPuJWe2K1JfMIVXNfahw1h3onJxQnxS8K0stKkogX05s+Aw==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.0.tgz",
+      "integrity": "sha512-n0B3s8rrqGrasTgNkXLKXzN0fXo+6IYP7M5b7AMsrZM33f/y6DS6kJ0Btd7SespASWq8bgL3taLo0oe0vB52IQ==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/semantic-conventions": "1.25.0"
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.0.tgz",
-      "integrity": "sha512-Eg/+Od5bEvzpvZQGhvMyKIkrzB9S7jW+6z9LHEI2VXhl/GrqQ3oBqlzJt4tA6pGtxRmqQWKWGM1wAbwDdW/gUA==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.0.tgz",
+      "integrity": "sha512-LPwSIrw+60cheWaXsfGL8stBap/AppKQJFE+qqRvzYrgttXFH2ofoIMxWadeqPTq4BYOXM/C7Bdh/T+B60xnlQ==",
       "requires": {
-        "@opentelemetry/api-logs": "0.51.0",
+        "@opentelemetry/api-logs": "0.52.0",
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.1",
+        "import-in-the-middle": "1.8.0",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
       }
     },
     "@opentelemetry/instrumentation-document-load": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-document-load/-/instrumentation-document-load-0.38.0.tgz",
-      "integrity": "sha512-X/AOG8sDcVp/bVGRWDDG7MCRjcmuQwZqG2B2C6/oj8V4koXPNRNDvW2GEIGJhF5/WxJxZsTRIGPG+yeJ52QOww==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-document-load/-/instrumentation-document-load-0.39.0.tgz",
+      "integrity": "sha512-M8QTHM1fFoJvQ1EYaxAF7V5RJhG4c+o4gWHLSFQl6dvQJuGiSdhM3azenRFcTe88Sn6AmVYRGiUjlac9GSVQ2g==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       }
     },
     "@opentelemetry/instrumentation-fetch": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.51.0.tgz",
-      "integrity": "sha512-dB9wisB2+wyh0wUB1RFNinCS4TqJ7QMVc4jNzy3JCMJudwFWI/stU10DgZ3vwFQNUEBUIz9QmEQSFud7lsvB2w==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.52.0.tgz",
+      "integrity": "sha512-ay1Ot0z/586MBnhZnWJJFWXjBCQjddVVjCxLPRECnorhzmXuOsjUb7zTY88Vv9ddRtcHe0EIp9Z8sWQeLT02kA==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/sdk-trace-web": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       }
     },
     "@opentelemetry/instrumentation-user-interaction": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-user-interaction/-/instrumentation-user-interaction-0.38.0.tgz",
-      "integrity": "sha512-/UZT7zZUpi3WavRW6GmxKSa3d3PQ1ApM9nG9PKq95d4w/zhXBaYiqGT/wzcyXefW4TL2oAq4sjJvt1rZpOlImA==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-user-interaction/-/instrumentation-user-interaction-0.39.0.tgz",
+      "integrity": "sha512-hO/D1g8/P1fo5lEEHpxHHnxXDRfysjBZdFGwR6oSIoZWAQW1EasxZRe2mYDnxc37vEZsFFxTWXayH+XMKOo/sw==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.52.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0"
       }
     },
     "@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.51.0.tgz",
-      "integrity": "sha512-KgLO2qx1z1Wn9NeJgrgNukd10ssK1QqxODwdeBJFO1BaP9sVVargpupYowlDKUL5I3oWOEqi/Oxxdh/fbEsJtw==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.52.0.tgz",
+      "integrity": "sha512-Q6dEFKBkVmLs6XByXNPkCZXYF1Ovs3fFCD33nA4d4dgBgv8zMPt7xBLIxfEw0QVDZhyBhKXwv7byvMDB+yYQdA==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/sdk-trace-web": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.0.tgz",
-      "integrity": "sha512-mxC7E7ocUS1tLzepnA7O9/G8G6ZTdjCH2pXme1DDDuCuk6n2/53GADX+GWBuyX0dfIxeMInIbJAdjlfN9GNr6A==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.0.tgz",
+      "integrity": "sha512-iHjydPMYJ+Li1auveJCq2rp5U2h6Mhq8BidiyE0jfVlDTFyR1ny8AfJHfmFzJ/RAM8vT8L7T21kcmGybxZC7lQ==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.0.tgz",
-      "integrity": "sha512-H9sLETZ4jw9UJ3totV8oM5R0m4CW0ZIOLfp4NV3g0CM8HD5zGZcaW88xqzWDgiYRpctFxd+WmHtGX/Upoa2vRg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.0.tgz",
+      "integrity": "sha512-6+g2fiRQUG39guCsKVeY8ToeuUf3YUnPkN6DXRA1qDmFLprlLvZm9cS6+chgbW70cZJ406FTtSCDnJwxDC5sGQ==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       }
     },
     "@opentelemetry/sdk-trace-web": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.24.0.tgz",
-      "integrity": "sha512-G0q8aZPUhRtO/iw2BkjHeNqCMBf0JQX5VqqiPWXn9u5iRkpeQ6LZrGaiymKWOdEqtXCgM44yrCY/4WoJqR0bjQ==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.25.0.tgz",
+      "integrity": "sha512-TAWRDRiVOeliE1A99z8idWb4pwEKKY9Vj5aTpLtrF4cvPOl0mPg3ZczvOw/HnpfRsWY0Ra/J3vS5uFSpoqPwEA==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.0.tgz",
-      "integrity": "sha512-yL0jI6Ltuz8R+Opj7jClGrul6pOoYrdfVmzQS4SITXRPH7I5IRZbrwe/6/v8v4WYMa6MYZG480S1+uc/IGfqsA=="
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ=="
     },
     "@types/shimmer": {
       "version": "1.0.5",
@@ -2635,10 +2607,10 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="
     },
-    "acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+    "acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "requires": {}
     },
     "ajv": {
@@ -3191,12 +3163,12 @@
       "dev": true
     },
     "import-in-the-middle": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.8.0.tgz",
+      "integrity": "sha512-/xQjze8szLNnJ5rvHSzn+dcVXqCAU6Plbk4P24U/jwPmg1wy7IIp9OjKIO5tYue8GSPhDpPDiApQjvBUmWwhsQ==",
       "requires": {
         "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
@@ -3311,14 +3283,6 @@
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "dev": true
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -3543,9 +3507,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "version": "4.3.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+          "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -3580,12 +3544,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
     },
     "serve": {
       "version": "14.2.3",
@@ -3726,12 +3687,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "peer": true
-    },
     "type-fest": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
@@ -3812,11 +3767,6 @@
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "yargs": {
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
@@ -3894,13 +3844,10 @@
       }
     },
     "zone.js": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.4.tgz",
-      "integrity": "sha512-NtTUvIlNELez7Q1DzKVIFZBzNb646boQMgpATo9z3Ftuu/gWvzxCW7jdjcUDoRGxRikrhVHB/zLXh1hxeJawvw==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.3.0"
-      }
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.6.tgz",
+      "integrity": "sha512-vyRNFqofdaHVdWAy7v3Bzmn84a1JHWSjpuTZROT/uYn8I3p2cmo7Ro9twFmYRQDPhiYOV7QLk0hhY4JJQVqS6Q==",
+      "peer": true
     }
   }
 }

--- a/examples/hello-world-web/package.json
+++ b/examples/hello-world-web/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@honeycombio/opentelemetry-web": "file:../../dist/src",
-    "@opentelemetry/auto-instrumentations-web": "~0.39.0"
+    "@opentelemetry/auto-instrumentations-web": "^0.40.0"
   },
   "devDependencies": {
     "chokidar": "^3.6.0",


### PR DESCRIPTION
## Which problem is this PR solving?

Updates our examples to use the `ignoreNetworkEvents` config option (which was [just released](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2211) today)

Also adds a button that makes an API call so that we can actually see the network spans.

## How to verify that this has the expected result

Run locally, look at exported spans, less events:

red rect is on the default config, green rect with `ignoreNetworkEvents = true`:
![image](https://github.com/honeycombio/honeycomb-opentelemetry-web/assets/11722214/8e3b1878-5eed-4b13-8552-77d088921445)
