### PR TITLE
feat: Allow defining `page.route`

### DIFF
--- a/examples/hello-world-react-create-app/package-lock.json
+++ b/examples/hello-world-react-create-app/package-lock.json
@@ -18,6 +18,8 @@
         "npm": "^10.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router": "^6.25.1",
+        "react-router-dom": "^6.25.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^4.0.1"
@@ -33,7 +35,8 @@
       }
     },
     "../..": {
-      "version": "0.4.0",
+      "name": "@honeycombio/opentelemetry-web",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
@@ -64,16 +67,19 @@
         "@typescript-eslint/eslint-plugin": "^7.0.2",
         "@typescript-eslint/parser": "^7.0.2",
         "cypress": "^13.6.4",
-        "eslint": "^8.57.0",
+        "eslint": "~8.57.0",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-config-react-app": "^7.0.1",
         "eslint-plugin-import": "^2.29.1",
         "husky": "^9.0.11",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-junit": "^16.0.0",
         "lint-staged": "^15.2.2",
         "prettier": "^3.2.5",
         "rollup": "^4.13.0",
         "rollup-plugin-analyzer": "^4.0.0",
+        "rollup-plugin-auto-external": "^2.0.0",
         "rollup-plugin-dts": "^6.1.1",
         "rollup-plugin-esbuild": "^6.1.1",
         "rollup-plugin-preserve-directives": "^0.4.0",
@@ -81,6 +87,9 @@
         "ts-jest": "^29.1.2",
         "tslib": "^2.6.3",
         "typescript": "^5.4.5"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.9.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3327,6 +3336,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.18.0.tgz",
+      "integrity": "sha512-L3jkqmqoSVBVKHfpGZmLrex0lxR5SucGA0sUfFzGctehw+S/ggL9L/0NnC5mw6P8HUWpFZ3nQw3cRApjjWx9Sw==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -15724,6 +15741,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.25.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.25.1.tgz",
+      "integrity": "sha512-u8ELFr5Z6g02nUtpPAggP73Jigj1mRePSwhS/2nkTrlPU5yEkH1vYzWNyvSnSzeeE2DNqWdH+P8OhIh9wuXhTw==",
+      "dependencies": {
+        "@remix-run/router": "1.18.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.25.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.25.1.tgz",
+      "integrity": "sha512-0tUDpbFvk35iv+N89dWNrJp+afLgd+y4VtorJZuOCXK0kkCWjEvb3vTJM++SYvMEpbVwXKf3FjeVveVEb6JpDQ==",
+      "dependencies": {
+        "@remix-run/router": "1.18.0",
+        "react-router": "6.25.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/examples/hello-world-react-create-app/package.json
+++ b/examples/hello-world-react-create-app/package.json
@@ -13,6 +13,8 @@
     "npm": "^10.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router": "^6.25.1",
+    "react-router-dom": "^6.25.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^4.0.1"

--- a/examples/hello-world-react-create-app/src/index.tsx
+++ b/examples/hello-world-react-create-app/src/index.tsx
@@ -4,8 +4,13 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
-import { HoneycombWebSDK } from '@honeycombio/opentelemetry-web';
+import {
+  HoneycombWebSDK,
+  DynamicAttributesSpanProcessor,
+} from '@honeycombio/opentelemetry-web';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
+import { RouterProvider } from 'react-router-dom';
+import { router } from './router';
 
 const configDefaults = {
   ignoreNetworkEvents: true,
@@ -17,6 +22,7 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <App />
+    <RouterProvider router={router} />
   </React.StrictMode>,
 );
 
@@ -28,7 +34,25 @@ root.render(
 // It's just for debugging purposes.
 reportWebVitals(console.log);
 
+function createRouteGetter() {
+  let route = window.location.pathname;
+  router.subscribe((state) => {
+    let newRoute = '';
+    // some shenanigans here since routes can be nested
+    for (let i = state.matches.length - 1; i >= 0; --i) {
+      const path = state.matches[i]?.route.path;
+      if (!path) continue;
+      if (!route.startsWith(path))
+        newRoute =
+          path + (newRoute.startsWith('/') ? newRoute : '/' + newRoute);
+    }
+    route = newRoute;
+  });
+  return () => route;
+}
+
 try {
+  const getRoute = createRouteGetter();
   const sdk = new HoneycombWebSDK({
     apiKey: 'api-key-goes-here',
     serviceName: 'hny-web-distro-example:hello-world-react-create-app',
@@ -39,6 +63,11 @@ try {
         '@opentelemetry/instrumentation-document-load': configDefaults,
       }),
     ], // add automatic instrumentation
+    spanProcessors: [
+      new DynamicAttributesSpanProcessor({
+        getAttributes: () => ({ 'page.route': getRoute() }),
+      }),
+    ],
   });
   sdk.start();
 } catch (err) {

--- a/examples/hello-world-react-create-app/src/router.tsx
+++ b/examples/hello-world-react-create-app/src/router.tsx
@@ -1,0 +1,17 @@
+import { createBrowserRouter, useParams } from 'react-router-dom';
+
+function Hello({ name }: { name?: string }) {
+  const params = useParams();
+  const paramName = params['name'];
+  return <h1>Hello {paramName ?? name}!</h1>;
+}
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Hello name="world" />,
+  },
+  {
+    path: '/:name',
+    element: <Hello />,
+  },
+]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@typescript-eslint/eslint-plugin": "^7.0.2",
         "@typescript-eslint/parser": "^7.0.2",
         "cypress": "^13.6.4",
-        "eslint": "^8.57.0",
+        "eslint": "~8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-react-app": "^7.0.1",
         "eslint-plugin-import": "^2.29.1",

--- a/src/browser-attributes-span-processor.ts
+++ b/src/browser-attributes-span-processor.ts
@@ -1,4 +1,3 @@
-import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { DynamicAttributesSpanProcessor } from './dynamic-attributes-span-processor';
 
 function getBrowserAttributes() {

--- a/src/browser-attributes-span-processor.ts
+++ b/src/browser-attributes-span-processor.ts
@@ -1,37 +1,29 @@
-import { Span } from '@opentelemetry/api';
 import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { DynamicAttributesSpanProcessor } from './dynamic-attributes-span-processor';
+
+function getBrowserAttributes() {
+  const { href, pathname, search, hash, hostname } = window.location;
+
+  return {
+    'browser.width': window.innerWidth,
+    'browser.height': window.innerHeight,
+    'page.hash': hash,
+    'page.url': href,
+    'page.route': pathname,
+    'page.hostname': hostname,
+    'page.search': search,
+
+    'url.path': pathname,
+  };
+}
 
 /**
  * A {@link SpanProcessor} that adds browser specific attributes to each span
  * that might change over the course of a session.
  * Static attributes (e.g. User Agent) are added to the Resource.
  */
-export class BrowserAttributesSpanProcessor implements SpanProcessor {
-  constructor() {}
-
-  onStart(span: Span) {
-    const { href, pathname, search, hash, hostname } = window.location;
-
-    span.setAttributes({
-      'browser.width': window.innerWidth,
-      'browser.height': window.innerHeight,
-      'page.hash': hash,
-      'page.url': href,
-      'page.route': pathname,
-      'page.hostname': hostname,
-      'page.search': search,
-
-      'url.path': pathname,
-    });
-  }
-
-  onEnd() {}
-
-  forceFlush() {
-    return Promise.resolve();
-  }
-
-  shutdown() {
-    return Promise.resolve();
+export class BrowserAttributesSpanProcessor extends DynamicAttributesSpanProcessor {
+  constructor() {
+    super({ getAttributes: getBrowserAttributes });
   }
 }

--- a/src/dynamic-attributes-span-processor.ts
+++ b/src/dynamic-attributes-span-processor.ts
@@ -1,0 +1,31 @@
+import { Attributes, Span } from '@opentelemetry/api';
+import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
+
+interface PageRouteSpanProcessorOptions {
+  getAttributes: () => Attributes;
+}
+
+/**
+ * A {@link SpanProcessor} that adds dynamic attributes to every span
+ */
+export class DynamicAttributesSpanProcessor implements SpanProcessor {
+  private getAttributes: () => Attributes;
+  constructor(options: PageRouteSpanProcessorOptions) {
+    this.getAttributes = options.getAttributes;
+  }
+
+  onStart(span: Span) {
+    const attributes = this.getAttributes();
+    span.setAttributes(attributes);
+  }
+
+  onEnd() {}
+
+  forceFlush() {
+    return Promise.resolve();
+  }
+
+  shutdown() {
+    return Promise.resolve();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './base-otel-sdk';
 export * from './honeycomb-otel-sdk';
 export * from './web-vitals-autoinstrumentation';
+export * from './dynamic-attributes-span-processor';


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When it comes to frontend it can be hard to know which "route" you're actually on. Currently the SDK will place `window.location.pathname` onto the `page.route` attribute. This is great for many cases, but in our application we have many routes such as `/entity/:entity_id` where it'd be nice to group them together.

## Short description of the changes

- Allow passing a `getRoute` function to the SDK which will be called to fill in `http.route`

## How to verify that this has the expected result

- View the test

## Possibilities

It should be possible for users to use the `getRoute` function to interrogate their router for what route they're actually on, or in more complex cases apply some inference based on the pathname (e.g. replace segments matching uuids with a placeholder)

For someone using react-router they might use a function like this:

```ts
function createRouteGetter(router) {
  let route = window.location.pathname
  router.subscribe(state => {
    let newRoute  = ""
    // some shenanigans here since routes can be nested
    for (let i = state.matches.length - 1; i >= 0; --i) {
      const path = state.matches[i]?.route.path
      if (!path) continue
      if (!route.startsWith(path)) newRoute = path + (newRoute.startsWith("/") ? newRoute : "/" + newRoute)
    }
    route = newRoute
  });
  return () => route
}

new HoneycombSDK({
  // ...
  getRoute: createRouteGetter(router)
})
```