### PR TITLE
feat: Add Global Error Instrumentation

### DIFF
--- a/src/global-errors-autoinstrumentation.ts
+++ b/src/global-errors-autoinstrumentation.ts
@@ -16,9 +16,14 @@ export interface GlobalErrorsInstrumentationConfig
  * @param config The {@link GlobalErrorsInstrumentationConfig}
  */
 export class GlobalErrorsInstrumentation extends InstrumentationAbstract {
+  private _isEnabled: boolean;
   constructor({ enabled = true }: GlobalErrorsInstrumentationConfig = {}) {
     const config: GlobalErrorsInstrumentationConfig = { enabled };
     super('@honeycombio/instrumentation-global-errors', VERSION, config);
+    if (enabled) {
+      this.enable();
+    }
+    this._isEnabled = enabled;
   }
 
   onError = (event: ErrorEvent | PromiseRejectionEvent) => {
@@ -42,12 +47,27 @@ export class GlobalErrorsInstrumentation extends InstrumentationAbstract {
   init() {}
 
   disable(): void {
+    if (!this.isEnabled()) {
+      this._diag.debug(`Instrumentation already disabled`);
+      return;
+    }
+    this._isEnabled = false;
     window.removeEventListener('error', this.onError);
     window.removeEventListener('unhandledrejection', this.onError);
+    this._diag.debug(`Instrumentation  disabled`);
   }
 
   enable(): void {
+    if (this.isEnabled()) {
+      this._diag.debug(`Instrumentation already enabled`);
+      return;
+    }
+    this._isEnabled = true;
     window.addEventListener('error', this.onError);
     window.addEventListener('unhandledrejection', this.onError);
+    this._diag.debug(`Instrumentation  enabled`);
+  }
+  public isEnabled() {
+    return this._isEnabled;
   }
 }

--- a/src/global-errors-autoinstrumentation.ts
+++ b/src/global-errors-autoinstrumentation.ts
@@ -1,0 +1,52 @@
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { InstrumentationAbstract } from './web-vitals-autoinstrumentation';
+import { VERSION } from './version';
+import { SpanStatusCode } from '@opentelemetry/api';
+import {
+  SEMATTRS_EXCEPTION_MESSAGE,
+  SEMATTRS_EXCEPTION_STACKTRACE,
+  SEMATTRS_EXCEPTION_TYPE,
+} from '@opentelemetry/semantic-conventions';
+
+export interface GlobalErrorsInstrumentationConfig
+  extends InstrumentationConfig {}
+
+/**
+ * Global errors auto-instrumentation, sends spans automatically for exceptions that reach the window.
+ * @param config The {@link GlobalErrorsInstrumentationConfig}
+ */
+export class GlobalErrorsInstrumentation extends InstrumentationAbstract {
+  constructor({ enabled = true }: GlobalErrorsInstrumentationConfig = {}) {
+    const config: GlobalErrorsInstrumentationConfig = { enabled };
+    super('@honeycombio/instrumentation-global-errors', VERSION, config);
+  }
+
+  onError = (event: ErrorEvent | PromiseRejectionEvent) => {
+    const error = 'reason' in event ? event.reason : event.error;
+    const message = error?.message;
+    const type = error?.name;
+    // otel spec requires at minimum these two
+    if (!message || !type) return;
+    const span = this.tracer.startSpan('exception', {
+      attributes: {
+        [SEMATTRS_EXCEPTION_TYPE]: type,
+        [SEMATTRS_EXCEPTION_MESSAGE]: message,
+        [SEMATTRS_EXCEPTION_STACKTRACE]: error?.stack,
+      },
+    });
+    span.setStatus({ code: SpanStatusCode.ERROR, message });
+    span.end();
+  };
+
+  init() {}
+
+  disable(): void {
+    window.removeEventListener('error', this.onError);
+    window.removeEventListener('unhandledrejection', this.onError);
+  }
+
+  enable(): void {
+    window.addEventListener('error', this.onError);
+    window.addEventListener('unhandledrejection', this.onError);
+  }
+}

--- a/src/global-errors-autoinstrumentation.ts
+++ b/src/global-errors-autoinstrumentation.ts
@@ -22,7 +22,8 @@ export class GlobalErrorsInstrumentation extends InstrumentationAbstract {
   }
 
   onError = (event: ErrorEvent | PromiseRejectionEvent) => {
-    const error = 'reason' in event ? event.reason : event.error;
+    const error: Error | undefined =
+      'reason' in event ? event.reason : event.error;
     const message = error?.message;
     const type = error?.name;
     // otel spec requires at minimum these two

--- a/src/honeycomb-otel-sdk.ts
+++ b/src/honeycomb-otel-sdk.ts
@@ -9,6 +9,7 @@ import { configureSpanProcessors } from './span-processor-builder';
 import { configureDeterministicSampler } from './deterministic-sampler';
 import { validateOptionsWarnings } from './validate-options';
 import { WebVitalsInstrumentation } from './web-vitals-autoinstrumentation';
+import { GlobalErrorsInstrumentation } from './global-errors-autoinstrumentation';
 
 export class HoneycombWebSDK extends WebSDK {
   constructor(options?: HoneycombOptions) {
@@ -17,6 +18,14 @@ export class HoneycombWebSDK extends WebSDK {
     if (options?.webVitalsInstrumentationConfig?.enabled !== false) {
       instrumentations.push(
         new WebVitalsInstrumentation(options?.webVitalsInstrumentationConfig),
+      );
+    }
+    // Automatically include global errors instrumentation unless explicitly set to false
+    if (options?.globalErrorsInstrumentationConfig?.enabled !== false) {
+      instrumentations.push(
+        new GlobalErrorsInstrumentation(
+          options?.globalErrorsInstrumentationConfig,
+        ),
       );
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ import {
   SpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { WebVitalsInstrumentationConfig } from './web-vitals-autoinstrumentation';
+import { GlobalErrorsInstrumentationConfig } from './global-errors-autoinstrumentation';
 
 export interface WebSDKConfiguration {
   autoDetectResources: boolean;
@@ -125,6 +126,7 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
 
   /** Config options for web vitals instrumentation. Enabled by default. */
   webVitalsInstrumentationConfig?: WebVitalsInstrumentationConfig;
+  globalErrorsInstrumentationConfig?: GlobalErrorsInstrumentationConfig;
 }
 
 /* Configure which fields to include in the `entry_page` resource attributes. By default,

--- a/test/global-errors-instrumentation.test.ts
+++ b/test/global-errors-instrumentation.test.ts
@@ -45,6 +45,7 @@ describe('Global Errors Instrumentation Tests', () => {
     // `unhandledrejection` is not dispatched in response to unhandled
     // rejections.
     it.skip('should create a span when a promise rejection is unhandled', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       timers
         .setTimeout()
         .then(() => Promise.reject(new Error('Something happened')));

--- a/test/global-errors-instrumentation.test.ts
+++ b/test/global-errors-instrumentation.test.ts
@@ -1,0 +1,62 @@
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { GlobalErrorsInstrumentation } from '../src/global-errors-autoinstrumentation';
+import timers from 'node:timers/promises';
+
+describe('Global Errors Instrumentation Tests', () => {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider();
+  const spanProcessor = new SimpleSpanProcessor(exporter);
+  provider.addSpanProcessor(spanProcessor);
+  provider.register();
+  let instr: GlobalErrorsInstrumentation;
+
+  beforeEach(() => {
+    instr = new GlobalErrorsInstrumentation();
+    instr.enable();
+  });
+
+  afterEach(() => {
+    instr.disable();
+    exporter.reset();
+  });
+
+  describe('when enabled', () => {
+    it('should create a span when an error escapes', async () => {
+      setTimeout(() => {
+        throw new Error('Something happened');
+      });
+      await timers.setTimeout();
+
+      const span = exporter.getFinishedSpans()[0];
+      expect(span.name).toBe('exception');
+      expect(span.attributes).toMatchObject({
+        'exception.type': 'Error',
+        'exception.message': 'Something happened',
+        'exception.stacktrace': expect.any(String),
+      });
+    });
+
+    // would love for this to work, but unfortunately jests underlying dom
+    // implementation doesn't control the promise implementation so
+    // `unhandledrejection` is not dispatched in response to unhandled
+    // rejections.
+    it.skip('should create a span when a promise rejection is unhandled', async () => {
+      timers
+        .setTimeout()
+        .then(() => Promise.reject(new Error('Something happened')));
+      await timers.setTimeout();
+
+      const span = exporter.getFinishedSpans()[0];
+      expect(span.name).toBe('exception');
+      expect(span.attributes).toMatchObject({
+        'exception.type': 'Error',
+        'exception.message': 'Something happened',
+        'exception.stacktrace': expect.any(String),
+      });
+    });
+  });
+});

--- a/test/honeycomb-debug.test.ts
+++ b/test/honeycomb-debug.test.ts
@@ -49,23 +49,23 @@ describe('when debug is set to true', () => {
       };
       new HoneycombWebSDK(testConfig);
       expect(consoleSpy).toHaveBeenNthCalledWith(
-        2,
+        3,
         '@honeycombio/opentelemetry-web: 🐝 Honeycomb Web SDK Debug Mode Enabled 🐝',
       );
       expect(consoleSpy).toHaveBeenNthCalledWith(
-        3,
+        4,
         `@honeycombio/opentelemetry-web: API Key configured for traces: '${testConfig.apiKey}'`,
       );
       expect(consoleSpy).toHaveBeenNthCalledWith(
-        4,
+        5,
         `@honeycombio/opentelemetry-web: Service Name configured for traces: '${testConfig.serviceName}'`,
       );
       expect(consoleSpy).toHaveBeenNthCalledWith(
-        5,
+        6,
         `@honeycombio/opentelemetry-web: Endpoint configured for traces: '${testConfig.endpoint}/${TRACES_PATH}'`,
       );
       expect(consoleSpy).toHaveBeenNthCalledWith(
-        6,
+        7,
         `@honeycombio/opentelemetry-web: Sample Rate configured for traces: '${testConfig.sampleRate}'`,
       );
     });


### PR DESCRIPTION
A few additions to [@nordfjor](https://github.com/nordfjord)'s excellent contribution here #181 

## Which problem is this PR solving?

Sometimes errors escape and it's useful to know what those errors were.
OpenTelemetry suggests these should go on the log signal, which does
make sense, but honeycomb doesn't really use that signal so it makes
sense for this to live in the honeycomb distribution.

## Short description of the changes

- Adds a new `GlobalErrorsInstrumentation`
- when enabled it attaches handlers to `unhandledrejection` and `error` events on the window
- The handler creates a span that matches the exception conventions from opentelemetry

## How to verify that this has the expected result
- Run the tests
- Use the sample Hello World app to send an uncaught error to Honeycomb

## Complications
- The jest environment is slightly different from actual browsers so I was unable to test the unhandled rejection flow, but have left a test that would work in an actual browser environment (marked as `it.skip` to avoid running it)
- Could not test with the instrumentation disabled because jest will fail any test that leaks an error automatically 