### PR TITLE
maint: Remove Pipeline team as code owners from web distro

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/pink-gremlins @honeycombio/pipeline-team
+* @honeycombio/pink-gremlins


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Removes the Pipeline team from code owners as discussed internally

## Short description of the changes

## How to verify that this has the expected result
