### PR TITLE
chore: Use Approximately equivalent to version for eslint b/c peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
     "cypress": "^13.6.4",
-    "eslint": "^8.57.0",
+    "eslint": "~8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-import": "^2.29.1",


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Address a build issue in https://github.com/honeycombio/honeycomb-opentelemetry-web/pull/195

## Short description of the changes
Use `~` rather than `^` for eslint dep. 

## How to verify that this has the expected result
