### PR TITLE
chore: dependabot should ignore major version upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,42 +5,45 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "weekly" # Check for updates every week
+      interval: 'weekly' # Check for updates every week
     labels:
-      - "type: dependencies" # Add label
+      - 'type: dependencies' # Add label
     reviewers:
-      - "honeycombio/pink-gremlins"
+      - 'honeycombio/pink-gremlins'
     commit-message:
-      prefix: "maint" # Add PR title prefix
-      include: "scope"
+      prefix: 'maint' # Add PR title prefix
+      include: 'scope'
     groups:
       otel:
         patterns:
-          - "@opentelemetry/*" # Update all otel dependencies together
+          - '@opentelemetry/*' # Update all otel dependencies together
       dev-dependencies: # Update dev dependencies together instead of piecemeal
         patterns:
-          - "@type*"
-          - "cypress"
-          - "eslint*"
-          - "jest*"
-          - "prettier"
-          - "ts-*"
-          - "typescript"
-  - package-ecosystem: "npm"
-    directory: "/examples/hello-world-web" # Location of package manifests
+          - '@type*'
+          - 'cypress'
+          - 'eslint*'
+          - 'jest*'
+          - 'prettier'
+          - 'ts-*'
+          - 'typescript'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major'] # Ignore major version updates for all packages.
+  - package-ecosystem: 'npm'
+    directory: '/examples/hello-world-web' # Location of package manifests
     schedule:
-      interval: "weekly" # Check for updates every week
+      interval: 'weekly' # Check for updates every week
     labels:
-      - "type: dependencies" # Add label
+      - 'type: dependencies' # Add label
     reviewers:
-      - "honeycombio/pink-gremlins"
+      - 'honeycombio/pink-gremlins'
     commit-message:
-      prefix: "maint" # Add PR title prefix
-      include: "scope"
+      prefix: 'maint' # Add PR title prefix
+      include: 'scope'
     groups:
       example-deps:
         patterns:
-          - "*" # Update all dependencies in example app
+          - '*' # Update all dependencies in example app


### PR DESCRIPTION
## Which problem is this PR solving?
We often get [failing dependabot PRs](https://github.com/honeycombio/honeycomb-opentelemetry-web/pull/207) because dependabot automatically tries to upgrade major versions. This isn't based on what we have in package.json so we have to specify in the dependabot config to ignore major version upgrades.

## Short description of the changes
- Add ignore section to dependabot config to ignore all major version upgrades

## How to verify that this has the expected result
- Dependabot config is valid
- Once this is merged, we should close the failing dependabot PR and when it reopens the PR it should only contain minor/patch upgrades.
