### PR TITLE
feat: Support multiple span processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Pass these options to the HoneycombWebSDK:
 | debug                 | optional                                         | boolean | false                   | Enable additional logging.                                                                                                                                                 |
 | dataset               | optional                                         | string  |                         | Populate this only if your Honeycomb environment is still [Classic](https://docs.honeycomb.io/honeycomb-classic/#am-i-using-honeycomb-classic).                                   |
 | skipOptionsValidation | optional                                         | boolean | false                   | Do not require any fields.[*](#send-to-an-opentelemetry-collector) Use with OpenTelemetry Collector.                                                                                                       |
+| spanProcessors | optional                                         | SpanProcessor[] | | Array of [span processors](https://opentelemetry.io/docs/languages/java/instrumentation/#span-processor) to apply to all generated spans.  |
 
 `*` Note: the `apiKey` field is required because this SDK really wants to help you send data directly to Honeycomb.
 

--- a/src/span-processor-builder.ts
+++ b/src/span-processor-builder.ts
@@ -53,6 +53,13 @@ export const configureSpanProcessors = (options?: HoneycombOptions) => {
     honeycombSpanProcessor.addProcessor(options?.spanProcessor);
   }
 
+  // if there is an array of spanProcessors provided, add them to the composite span processor
+  if (options?.spanProcessors) {
+    options.spanProcessors.forEach((processor) => {
+      honeycombSpanProcessor.addProcessor(processor);
+    });
+  }
+
   return honeycombSpanProcessor;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,13 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
    */
   serviceName?: string;
 
+  /** Provide an array of span processors that should be applied to all spans.
+   * Use this to specify synchronous hooks that can add to a span once the span is started or ended.
+   * The processors will be applied in the order they are specified.
+   * E.g. adding attributes to a span.
+   */
+  spanProcessors?: SpanProcessor[];
+
   /** The sample rate used to determine whether a trace is exported.
    * This must be a whole positive number. Only 1 out of every `sampleRate` traces will be randomly selected to be sent.
    * Set to 0 to drop everything.

--- a/test/span-processor-builder.test.ts
+++ b/test/span-processor-builder.test.ts
@@ -126,6 +126,7 @@ describe('configureSpanProcessors', () => {
       'url.path': '/some-page',
     });
   });
+
   test('Configures additional user provided span processor', () => {
     const honeycombSpanProcessors = configureSpanProcessors({
       spanProcessor: new TestSpanProcessorOne(),
@@ -146,6 +147,29 @@ describe('configureSpanProcessors', () => {
       'page.url':
         'http://something-something.com/some-page?search_params=yes&hello=hi#the-hash',
       'processor1.name': 'TestSpanProcessorOne',
+      'url.path': '/some-page',
+    });
+  });
+
+  test('Configures array of span processors if provided', () => {
+    const honeycombSpanProcessors = configureSpanProcessors({
+      spanProcessors: [new TestSpanProcessorOne(), new TestSpanProcessorTwo()],
+    });
+
+    expect(honeycombSpanProcessors.getSpanProcessors()).toHaveLength(5);
+
+    honeycombSpanProcessors.onStart(span, ROOT_CONTEXT);
+    expect(span.attributes).toEqual({
+      'browser.width': 1024,
+      'browser.height': 768,
+      'page.hash': '#the-hash',
+      'page.hostname': 'something-something.com',
+      'page.route': '/some-page',
+      'page.search': '?search_params=yes&hello=hi',
+      'page.url':
+        'http://something-something.com/some-page?search_params=yes&hello=hi#the-hash',
+      'processor1.name': 'TestSpanProcessorOne',
+      'processor2.name': 'TestSpanProcessorTwo',
       'url.path': '/some-page',
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #211 

## Short description of the changes
- Allows users to provide an array of span processors to be applied to all spans.
- Currently support both `spanProcessor` and `spanProcessors` but should favour `spanProcessors` in all documentation.

## How to verify that this has the expected result
- Tests pass
- Run the example and provide an array of span processors.
