### PR TITLE
docs: Tell people about the session ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This package sets up OpenTelemetry for tracing, using our recommended practices,
 * Easy configuration to send to Honeycomb
 * Basic sampler to control event volume
 * Multi span attributes
+* 'session.id' on every span, generated on page load
 * Convenient packaging
 * An informative debug mode
 * Links to traces in Honeycomb


### PR DESCRIPTION
I wanted the Session ID processor, and I didn't realize it was on this SDK (and implemented by default) until I dug around in the code.

<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #<enter issue here>

## Short description of the changes

README only

## How to verify that this has the expected result
