### PR TITLE
docs: Add example for a span processor that hooks into react router

### DIFF
--- a/packages/honeycomb-opentelemetry-web/examples/hello-world-react-create-app/package-lock.json
+++ b/packages/honeycomb-opentelemetry-web/examples/hello-world-react-create-app/package-lock.json
@@ -18,6 +18,7 @@
         "npm": "^10.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^4.0.1"
@@ -33,7 +34,8 @@
       }
     },
     "../..": {
-      "version": "0.4.0",
+      "name": "@honeycombio/opentelemetry-web",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
@@ -64,16 +66,19 @@
         "@typescript-eslint/eslint-plugin": "^7.0.2",
         "@typescript-eslint/parser": "^7.0.2",
         "cypress": "^13.6.4",
-        "eslint": "^8.57.0",
+        "eslint": "~8.57.0",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-config-react-app": "^7.0.1",
         "eslint-plugin-import": "^2.29.1",
         "husky": "^9.0.11",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-junit": "^16.0.0",
         "lint-staged": "^15.2.2",
         "prettier": "^3.2.5",
         "rollup": "^4.13.0",
         "rollup-plugin-analyzer": "^4.0.0",
+        "rollup-plugin-auto-external": "^2.0.0",
         "rollup-plugin-dts": "^6.1.1",
         "rollup-plugin-esbuild": "^6.1.1",
         "rollup-plugin-preserve-directives": "^0.4.0",
@@ -81,6 +86,9 @@
         "ts-jest": "^29.1.2",
         "tslib": "^2.6.3",
         "typescript": "^5.4.5"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.9.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3327,6 +3335,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.0.tgz",
+      "integrity": "sha512-zDICCLKEwbVYTS6TjYaWtHXxkdoUvD/QXvyVZjGCsWz5vyH7aFeONlPffPdW+Y/t6KT0MgXb2Mfjun9YpWN1dA==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -15724,6 +15740,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.0.tgz",
+      "integrity": "sha512-wVQq0/iFYd3iZ9H2l3N3k4PL8EEHcb0XlU2Na8nEwmiXgIUElEH6gaJDtUQxJ+JFzmIXaQjfdpcGWaM6IoQGxg==",
+      "dependencies": {
+        "@remix-run/router": "1.19.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.0.tgz",
+      "integrity": "sha512-RRGUIiDtLrkX3uYcFiCIxKFWMcWQGMojpYZfcstc63A1+sSnVgILGIm9gNUA6na3Fm1QuPGSBQH2EMbAZOnMsQ==",
+      "dependencies": {
+        "@remix-run/router": "1.19.0",
+        "react-router": "6.26.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/packages/honeycomb-opentelemetry-web/examples/hello-world-react-create-app/package.json
+++ b/packages/honeycomb-opentelemetry-web/examples/hello-world-react-create-app/package.json
@@ -13,6 +13,7 @@
     "npm": "^10.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^4.0.1"

--- a/packages/honeycomb-opentelemetry-web/examples/hello-world-react-create-app/src/index.tsx
+++ b/packages/honeycomb-opentelemetry-web/examples/hello-world-react-create-app/src/index.tsx
@@ -3,20 +3,60 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-
+import {
+  createBrowserRouter,
+  Link,
+  RouterProvider,
+  useParams,
+} from 'react-router-dom';
 import { HoneycombWebSDK } from '@honeycombio/opentelemetry-web';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
+import { ReactRouterSpanProcessor } from './reactRouterSpanProcessor';
 
 const configDefaults = {
   ignoreNetworkEvents: true,
 };
+
+const Name = () => {
+  const { name } = useParams();
+  return (
+    <div>
+      {name} <Link to={'/'}>Home</Link>
+    </div>
+  );
+};
+
+const Pet = () => {
+  const { name, pet } = useParams();
+  return (
+    <div>
+      {name} has a pet {pet}
+      <Link to={`/name/${name}`}>Back to person</Link>
+    </div>
+  );
+};
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+  },
+  {
+    path: 'name/:name',
+    element: <Name />,
+  },
+  {
+    path: 'name/:name/pet/:pet',
+    element: <Pet />,
+  },
+]);
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>,
 );
 
@@ -30,6 +70,7 @@ reportWebVitals(console.log);
 
 try {
   const sdk = new HoneycombWebSDK({
+    debug: true,
     apiKey: 'api-key-goes-here',
     serviceName: 'hny-web-distro-example:hello-world-react-create-app',
     instrumentations: [
@@ -39,6 +80,7 @@ try {
         '@opentelemetry/instrumentation-document-load': configDefaults,
       }),
     ], // add automatic instrumentation
+    spanProcessors: [new ReactRouterSpanProcessor({ router })],
   });
   sdk.start();
 } catch (err) {

--- a/packages/honeycomb-opentelemetry-web/examples/hello-world-react-create-app/src/reactRouterSpanProcessor.ts
+++ b/packages/honeycomb-opentelemetry-web/examples/hello-world-react-create-app/src/reactRouterSpanProcessor.ts
@@ -1,0 +1,50 @@
+import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { Span } from '@opentelemetry/api';
+
+function createRouteGetter(router: any) {
+  let route = router.state.matches[router.state.matches.length - 1]?.route.path;
+  router.subscribe((state: any) => {
+    route = state.matches[state.matches.length - 1]?.route.path;
+  });
+  return () => route;
+}
+
+/**
+ * SpanProcessor that adds attributes to spans based on the state of the React Router
+ * Sets the page.route attribute to the generic dynamic route
+ * Records the span as an error if there are errors in the router state (e.g. 404)
+ */
+export class ReactRouterSpanProcessor implements SpanProcessor {
+  router;
+  constructor({ router }: { router: any }) {
+    this.router = router;
+  }
+
+  onStart(span: Span) {
+    const { errors } = this.router.state;
+
+    // If there are errors, set the span status to error and record the error message
+    if (errors !== null) {
+      span.setStatus({
+        code: 2,
+        message: errors[0].data,
+      });
+    }
+
+    // Set the page.route as the generic dynamic route, making things easier to query
+    // e.g. /name/:name/pet/:pet instead of name/123/pet/456
+    // url.path attribute will have the more specific computed route
+    const pageRoute = createRouteGetter(this.router)();
+    span.setAttributes({ 'page.route': pageRoute });
+  }
+
+  onEnd() {}
+
+  forceFlush() {
+    return Promise.resolve();
+  }
+
+  shutdown() {
+    return Promise.resolve();
+  }
+}


### PR DESCRIPTION
**Do not merge until next release**

## Which problem is this PR solving?
- Adds an example of how to hook into React Router with a span processor

## Short description of the changes
- Adds a `ReactRouterSpanProcessor` to the CRA example

## How to verify that this has the expected result
- Run the react app example, you should see `page.route` set to the dynamic route instead of a specific one.
