### PR TITLE
fix: Make applyCustomAttributes optional.

### DIFF
--- a/packages/honeycomb-opentelemetry-web/examples/hello-world-react-create-app/src/index.tsx
+++ b/packages/honeycomb-opentelemetry-web/examples/hello-world-react-create-app/src/index.tsx
@@ -73,6 +73,10 @@ try {
     debug: true,
     apiKey: 'api-key-goes-here',
     serviceName: 'hny-web-distro-example:hello-world-react-create-app',
+    webVitalsInstrumentationConfig: {
+      vitalsToTrack: ['CLS', 'FCP', 'FID', 'INP', 'LCP', 'TTFB'],
+      inp: { includeTimingsAsSpans: true },
+    },
     instrumentations: [
       getWebAutoInstrumentations({
         '@opentelemetry/instrumentation-xml-http-request': configDefaults,

--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -228,10 +228,6 @@ export interface WebVitalsInstrumentationConfig extends InstrumentationConfig {
   ttfb?: VitalOpts;
 }
 
-const noop = () => {
-  // No-op
-};
-
 /**
  * Web vitals auto-instrumentation, sends spans automatically for CLS, LCP, INP, FCP, FID, TTFB.
  * Defaults to sending spans for CLS, LCP, INP, FCP and TTFB.
@@ -423,7 +419,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
 
   onReportCLS = (
     cls: CLSMetricWithAttribution,
-    applyCustomAttributes: ApplyCustomAttributesFn = noop,
+    applyCustomAttributes?: ApplyCustomAttributesFn,
   ) => {
     if (!this.isEnabled()) return;
 
@@ -448,13 +444,16 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.had_recent_input`]: largestShiftEntry?.hadRecentInput,
     });
 
-    applyCustomAttributes(cls, span);
+    if (applyCustomAttributes) {
+      applyCustomAttributes(cls, span);
+    }
+
     span.end();
   };
 
   onReportLCP = (
     lcp: LCPMetricWithAttribution,
-    applyCustomAttributes: ApplyCustomAttributesFn = noop,
+    applyCustomAttributes?: ApplyCustomAttributesFn,
   ) => {
     if (!this.isEnabled()) return;
 
@@ -482,13 +481,16 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.resource_load_time`]: resourceLoadDuration,
     });
 
-    applyCustomAttributes(lcp, span);
+    if (applyCustomAttributes) {
+      applyCustomAttributes(lcp, span);
+    }
+
     span.end();
   };
 
   onReportINP = (
     inp: INPMetricWithAttribution,
-    applyCustomAttributes: ApplyCustomAttributesFn = noop,
+    applyCustomAttributes?: ApplyCustomAttributesFn,
     includeTimingsAsSpans = false,
   ) => {
     if (!this.isEnabled()) return;
@@ -531,7 +533,9 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
 
         inpSpan.setAttributes(inpAttributes);
 
-        applyCustomAttributes(inp, inpSpan);
+        if (applyCustomAttributes) {
+          applyCustomAttributes(inp, inpSpan);
+        }
 
         if (includeTimingsAsSpans) {
           longAnimationFrameEntries.forEach((perfEntry) => {
@@ -541,7 +545,6 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
             );
           });
         }
-
         inpSpan.end(interactionTime + inpDuration);
       },
     );
@@ -549,7 +552,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
 
   onReportFCP = (
     fcp: FCPMetricWithAttribution,
-    applyCustomAttributes: ApplyCustomAttributesFn = noop,
+    applyCustomAttributes?: ApplyCustomAttributesFn,
   ) => {
     if (!this.isEnabled()) return;
 
@@ -567,7 +570,10 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.load_state`]: loadState,
     });
 
-    applyCustomAttributes(fcp, span);
+    if (applyCustomAttributes) {
+      applyCustomAttributes(fcp, span);
+    }
+
     span.end();
   };
 
@@ -576,7 +582,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
    */
   onReportFID = (
     fid: FIDMetricWithAttribution,
-    applyCustomAttributes: ApplyCustomAttributesFn = noop,
+    applyCustomAttributes?: ApplyCustomAttributesFn,
   ) => {
     if (!this.isEnabled()) return;
 
@@ -593,13 +599,16 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.load_state`]: loadState,
     });
 
-    applyCustomAttributes(fid, span);
+    if (applyCustomAttributes) {
+      applyCustomAttributes(fid, span);
+    }
+
     span.end();
   };
 
   onReportTTFB = (
     ttfb: TTFBMetricWithAttribution,
-    applyCustomAttributes: ApplyCustomAttributesFn = noop,
+    applyCustomAttributes?: ApplyCustomAttributesFn,
   ) => {
     if (!this.isEnabled()) return;
 
@@ -628,7 +637,9 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
 
     const span = this.tracer.startSpan(name);
     span.setAttributes(attributes);
-    applyCustomAttributes(ttfb, span);
+    if (applyCustomAttributes) {
+      applyCustomAttributes(ttfb, span);
+    }
     span.end();
   };
 

--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -85,7 +85,7 @@ interface VitalOpts extends ReportOpts {
    *  }
    * }
    */
-  applyCustomAttributes: ApplyCustomAttributesFn;
+  applyCustomAttributes?: ApplyCustomAttributesFn;
 }
 
 interface VitalOptsWithTimings extends VitalOpts {
@@ -227,6 +227,10 @@ export interface WebVitalsInstrumentationConfig extends InstrumentationConfig {
   /** Config specific to TTFB (Time To First Byte) */
   ttfb?: VitalOpts;
 }
+
+const noop = () => {
+  // No-op
+};
 
 /**
  * Web vitals auto-instrumentation, sends spans automatically for CLS, LCP, INP, FCP, FID, TTFB.
@@ -419,7 +423,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
 
   onReportCLS = (
     cls: CLSMetricWithAttribution,
-    applyCustomAttributes?: ApplyCustomAttributesFn,
+    applyCustomAttributes: ApplyCustomAttributesFn = noop,
   ) => {
     if (!this.isEnabled()) return;
 
@@ -444,16 +448,13 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.had_recent_input`]: largestShiftEntry?.hadRecentInput,
     });
 
-    if (applyCustomAttributes) {
-      applyCustomAttributes(cls, span);
-    }
-
+    applyCustomAttributes(cls, span);
     span.end();
   };
 
   onReportLCP = (
     lcp: LCPMetricWithAttribution,
-    applyCustomAttributes?: ApplyCustomAttributesFn,
+    applyCustomAttributes: ApplyCustomAttributesFn = noop,
   ) => {
     if (!this.isEnabled()) return;
 
@@ -481,16 +482,13 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.resource_load_time`]: resourceLoadDuration,
     });
 
-    if (applyCustomAttributes) {
-      applyCustomAttributes(lcp, span);
-    }
-
+    applyCustomAttributes(lcp, span);
     span.end();
   };
 
   onReportINP = (
     inp: INPMetricWithAttribution,
-    applyCustomAttributes?: ApplyCustomAttributesFn,
+    applyCustomAttributes: ApplyCustomAttributesFn = noop,
     includeTimingsAsSpans = false,
   ) => {
     if (!this.isEnabled()) return;
@@ -533,9 +531,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
 
         inpSpan.setAttributes(inpAttributes);
 
-        if (applyCustomAttributes) {
-          applyCustomAttributes(inp, inpSpan);
-        }
+        applyCustomAttributes(inp, inpSpan);
 
         if (includeTimingsAsSpans) {
           longAnimationFrameEntries.forEach((perfEntry) => {
@@ -545,6 +541,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
             );
           });
         }
+
         inpSpan.end(interactionTime + inpDuration);
       },
     );
@@ -552,7 +549,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
 
   onReportFCP = (
     fcp: FCPMetricWithAttribution,
-    applyCustomAttributes?: ApplyCustomAttributesFn,
+    applyCustomAttributes: ApplyCustomAttributesFn = noop,
   ) => {
     if (!this.isEnabled()) return;
 
@@ -570,10 +567,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.load_state`]: loadState,
     });
 
-    if (applyCustomAttributes) {
-      applyCustomAttributes(fcp, span);
-    }
-
+    applyCustomAttributes(fcp, span);
     span.end();
   };
 
@@ -582,7 +576,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
    */
   onReportFID = (
     fid: FIDMetricWithAttribution,
-    applyCustomAttributes?: ApplyCustomAttributesFn,
+    applyCustomAttributes: ApplyCustomAttributesFn = noop,
   ) => {
     if (!this.isEnabled()) return;
 
@@ -599,16 +593,13 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [`${attrPrefix}.load_state`]: loadState,
     });
 
-    if (applyCustomAttributes) {
-      applyCustomAttributes(fid, span);
-    }
-
+    applyCustomAttributes(fid, span);
     span.end();
   };
 
   onReportTTFB = (
     ttfb: TTFBMetricWithAttribution,
-    applyCustomAttributes?: ApplyCustomAttributesFn,
+    applyCustomAttributes: ApplyCustomAttributesFn = noop,
   ) => {
     if (!this.isEnabled()) return;
 
@@ -637,9 +628,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
 
     const span = this.tracer.startSpan(name);
     span.setAttributes(attributes);
-    if (applyCustomAttributes) {
-      applyCustomAttributes(ttfb, span);
-    }
+    applyCustomAttributes(ttfb, span);
     span.end();
   };
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->


## Which problem is this PR solving?

Makes the `ApplyCustomAttributesFn` optional since it's guarded against. 
## Short description of the changes
Makes the `ApplyCustomAttributesFn` optional for `webVitalsInstrumentationConfig`, updates example app to exercise that. 
## How to verify that this has the expected result
