### PR TITLE
feat: Add log level config option to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Pass these options to the HoneycombWebSDK:
 | spanProcessors | optional                                         | SpanProcessor[] | | Array of [span processors](https://opentelemetry.io/docs/languages/java/instrumentation/#span-processor) to apply to all generated spans.  |
 |  webVitalsInstrumentationConfig|optional|WebVitalsInstrumentationConfig| `{ enabled: true }` | See [WebVitalsInstrumentationConfig](####WebVitalsInstrumentationConfig). |
 |  globalErrorsInstrumentationConfig |optional| GlobalErrorsInstrumentationConfig|  `{ enabled: true }` | See [GlobalErrorsInstrumentationConfig](####GlobalErrorsInstrumentationConfig).
-| logLevel              | optional                                    | DiagLogLevel | DiagLogLevel.INFO       | Controls the verbosity of logs printed to the console. Currently, only controls logs printed for SDK option validation. |
+| logLevel              | optional                                    | DiagLogLevel | DiagLogLevel.DEBUG       | Controls the verbosity of logs printed to the console. Currently, only controls logs printed for SDK option validation. |
 
 `*` Note: the `apiKey` field is required because this SDK really wants to help you send data directly to Honeycomb.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Pass these options to the HoneycombWebSDK:
 | spanProcessors | optional                                         | SpanProcessor[] | | Array of [span processors](https://opentelemetry.io/docs/languages/java/instrumentation/#span-processor) to apply to all generated spans.  |
 |  webVitalsInstrumentationConfig|optional|WebVitalsInstrumentationConfig| `{ enabled: true }` | See [WebVitalsInstrumentationConfig](####WebVitalsInstrumentationConfig). |
 |  globalErrorsInstrumentationConfig |optional| GlobalErrorsInstrumentationConfig|  `{ enabled: true }` | See [GlobalErrorsInstrumentationConfig](####GlobalErrorsInstrumentationConfig).
+| logLevel              | optional                                    | DiagLogLevel | DiagLogLevel.INFO       | Controls the verbosity of logs printed to the console. Currently, only controls logs printed for SDK option validation. |
 
 `*` Note: the `apiKey` field is required because this SDK really wants to help you send data directly to Honeycomb.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Pass these options to the HoneycombWebSDK:
 | spanProcessors | optional                                         | SpanProcessor[] | | Array of [span processors](https://opentelemetry.io/docs/languages/java/instrumentation/#span-processor) to apply to all generated spans.  |
 |  webVitalsInstrumentationConfig|optional|WebVitalsInstrumentationConfig| `{ enabled: true }` | See [WebVitalsInstrumentationConfig](####WebVitalsInstrumentationConfig). |
 |  globalErrorsInstrumentationConfig |optional| GlobalErrorsInstrumentationConfig|  `{ enabled: true }` | See [GlobalErrorsInstrumentationConfig](####GlobalErrorsInstrumentationConfig).
-| logLevel              | optional                                    | DiagLogLevel | DiagLogLevel.DEBUG       | Controls the verbosity of logs printed to the console. Currently, only controls logs printed for SDK option validation. |
+| logLevel              | optional                                    | DiagLogLevel | DiagLogLevel.DEBUG       | Controls the verbosity of logs printed to the console. |
 
 `*` Note: the `apiKey` field is required because this SDK really wants to help you send data directly to Honeycomb.
 

--- a/packages/honeycomb-opentelemetry-web/src/console-trace-link-exporter.ts
+++ b/packages/honeycomb-opentelemetry-web/src/console-trace-link-exporter.ts
@@ -45,8 +45,9 @@ class ConsoleTraceLinkExporter implements SpanExporter {
     }
 
     if (!serviceName || !apikey) {
-      this._logLevel >= DiagLogLevel.DEBUG &&
+      if (this._logLevel >= DiagLogLevel.DEBUG) {
         console.debug(MISSING_FIELDS_FOR_LOCAL_VISUALIZATIONS);
+      }
       return;
     }
 
@@ -76,8 +77,9 @@ class ConsoleTraceLinkExporter implements SpanExporter {
         }
       })
       .catch(() => {
-        this._logLevel >= DiagLogLevel.INFO &&
+        if (this._logLevel >= DiagLogLevel.INFO) {
           console.log(FAILED_AUTH_FOR_LOCAL_VISUALIZATIONS);
+        }
       });
   }
 
@@ -88,13 +90,12 @@ class ConsoleTraceLinkExporter implements SpanExporter {
     if (this._traceUrl) {
       spans.forEach((span) => {
         // only log root spans (ones without a parent span)
-        if (!span.parentSpanId) {
-          this._logLevel >= DiagLogLevel.INFO &&
-            console.log(
-              createHoneycombSDKLogMessage(
-                `Honeycomb link: ${this._traceUrl}=${span.spanContext().traceId}`,
-              ),
-            );
+        if (!span.parentSpanId && this._logLevel >= DiagLogLevel.INFO) {
+          console.log(
+            createHoneycombSDKLogMessage(
+              `Honeycomb link: ${this._traceUrl}=${span.spanContext().traceId}`,
+            ),
+          );
         }
       });
     }

--- a/packages/honeycomb-opentelemetry-web/src/types.ts
+++ b/packages/honeycomb-opentelemetry-web/src/types.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { ContextManager } from '@opentelemetry/api';
+import type { ContextManager, DiagLogLevel } from '@opentelemetry/api';
 import { TextMapPropagator } from '@opentelemetry/api';
 import { Instrumentation } from '@opentelemetry/instrumentation';
 import {
@@ -136,9 +136,10 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
   globalErrorsInstrumentationConfig?: GlobalErrorsInstrumentationConfig;
 
   /**
-   * Controls the verbosity of the logs. Defaults to 'DEBUG'. Current options are 'DEBUG', 'INFO', 'WARN', and 'ERROR'.
+   * Controls the verbosity of logs. Utilizes OpenTelemetry's `DiagLogLevel` enums. Defaults to 'DEBUG'.
+   * Current options include 'NONE', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'VERBOSE', and 'ALL'.
    */
-  logLevel?: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
+  logLevel?: DiagLogLevel;
 }
 
 /* Configure which fields to include in the `entry_page` resource attributes. By default,
@@ -170,10 +171,3 @@ export type EntryPageConfig = {
    * Defaults to 'false' */
   search?: boolean;
 };
-
-export enum LogLevel {
-  DEBUG,
-  INFO,
-  WARN,
-  ERROR,
-}

--- a/packages/honeycomb-opentelemetry-web/src/types.ts
+++ b/packages/honeycomb-opentelemetry-web/src/types.ts
@@ -95,7 +95,7 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
    */
   sampleRate?: number;
 
-  /** The debug flag enables additional logging that us useful when debugging your application. Do not use in production.
+  /** The debug flag enables additional logging that is useful when debugging your application. Do not use in production.
    * Defaults to 'false'.
    */
   debug?: boolean;
@@ -134,6 +134,11 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
   /** Config options for web vitals instrumentation. Enabled by default. */
   webVitalsInstrumentationConfig?: WebVitalsInstrumentationConfig;
   globalErrorsInstrumentationConfig?: GlobalErrorsInstrumentationConfig;
+
+  /**
+   * Controls the verbosity of the logs. Defaults to 'info'.
+   */
+  logLevel?: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 }
 
 /* Configure which fields to include in the `entry_page` resource attributes. By default,

--- a/packages/honeycomb-opentelemetry-web/src/types.ts
+++ b/packages/honeycomb-opentelemetry-web/src/types.ts
@@ -136,7 +136,7 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
   globalErrorsInstrumentationConfig?: GlobalErrorsInstrumentationConfig;
 
   /**
-   * Controls the verbosity of the logs. Defaults to 'info'.
+   * Controls the verbosity of the logs. Defaults to 'DEBUG'. Current options are 'DEBUG', 'INFO', 'WARN', and 'ERROR'.
    */
   logLevel?: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 }

--- a/packages/honeycomb-opentelemetry-web/src/types.ts
+++ b/packages/honeycomb-opentelemetry-web/src/types.ts
@@ -136,7 +136,7 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
   globalErrorsInstrumentationConfig?: GlobalErrorsInstrumentationConfig;
 
   /**
-   * Controls the verbosity of logs. Utilizes OpenTelemetry's `DiagLogLevel` enums. Defaults to 'DEBUG'.
+   * Controls the verbosity of logs. Utilizes OpenTelemetry's `DiagLogLevel` enum. Defaults to 'DEBUG'.
    * Current options include 'NONE', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'VERBOSE', and 'ALL'.
    */
   logLevel?: DiagLogLevel;

--- a/packages/honeycomb-opentelemetry-web/src/types.ts
+++ b/packages/honeycomb-opentelemetry-web/src/types.ts
@@ -170,3 +170,10 @@ export type EntryPageConfig = {
    * Defaults to 'false' */
   search?: boolean;
 };
+
+export enum LogLevel {
+  DEBUG,
+  INFO,
+  WARN,
+  ERROR,
+}

--- a/packages/honeycomb-opentelemetry-web/src/validate-options.ts
+++ b/packages/honeycomb-opentelemetry-web/src/validate-options.ts
@@ -37,7 +37,6 @@ export const validateOptionsWarnings = (options?: HoneycombOptions) => {
   const logLevel: DiagLogLevel = options?.logLevel
     ? options.logLevel
     : DiagLogLevel.DEBUG;
-  console.log('logLevel:', logLevel);
 
   if (options?.skipOptionsValidation) {
     if (logLevel === DiagLogLevel.DEBUG) {

--- a/packages/honeycomb-opentelemetry-web/src/validate-options.ts
+++ b/packages/honeycomb-opentelemetry-web/src/validate-options.ts
@@ -32,33 +32,56 @@ export const FAILED_AUTH_FOR_LOCAL_VISUALIZATIONS =
     '🔕 Failed to get proper auth response from Honeycomb. No local visualization available.',
   );
 
+enum LogLevel {
+  DEBUG,
+  INFO,
+  WARN,
+  ERROR,
+}
+
 export const validateOptionsWarnings = (options?: HoneycombOptions) => {
+  const logLevel = options?.logLevel
+    ? LogLevel[options.logLevel]
+    : LogLevel.INFO;
+
   if (options?.skipOptionsValidation) {
-    console.debug(SKIPPING_OPTIONS_VALIDATION_MSG);
+    if (logLevel === LogLevel.DEBUG) {
+      console.debug(SKIPPING_OPTIONS_VALIDATION_MSG);
+    }
     return;
   }
   // warn if api key is missing
-  if (!options?.apiKey) {
+  if (!options?.apiKey && logLevel <= LogLevel.WARN) {
     console.warn(MISSING_API_KEY_ERROR);
   }
 
   // warn if service name is missing
-  if (!options?.serviceName) {
+  if (!options?.serviceName && logLevel <= LogLevel.WARN) {
     console.warn(MISSING_SERVICE_NAME_ERROR);
   }
 
   // warn if dataset is set while using an environment-aware key
-  if (options?.apiKey && !isClassic(options?.apiKey) && options?.dataset) {
+  if (
+    options?.apiKey &&
+    !isClassic(options?.apiKey) &&
+    options?.dataset &&
+    logLevel <= LogLevel.WARN
+  ) {
     console.warn(IGNORED_DATASET_ERROR);
   }
 
   // warn if dataset is missing if using classic key
-  if (options?.apiKey && isClassic(options?.apiKey) && !options?.dataset) {
+  if (
+    options?.apiKey &&
+    isClassic(options?.apiKey) &&
+    !options?.dataset &&
+    logLevel <= LogLevel.WARN
+  ) {
     console.warn(MISSING_DATASET_ERROR);
   }
 
   // warn if custom sampler provided
-  if (options?.sampler) {
+  if (options?.sampler && logLevel === LogLevel.DEBUG) {
     console.debug(SAMPLER_OVERRIDE_WARNING);
   }
 

--- a/packages/honeycomb-opentelemetry-web/src/validate-options.ts
+++ b/packages/honeycomb-opentelemetry-web/src/validate-options.ts
@@ -39,7 +39,7 @@ export const validateOptionsWarnings = (options?: HoneycombOptions) => {
     : DiagLogLevel.DEBUG;
 
   if (options?.skipOptionsValidation) {
-    if (logLevel === DiagLogLevel.DEBUG) {
+    if (logLevel >= DiagLogLevel.DEBUG) {
       console.debug(SKIPPING_OPTIONS_VALIDATION_MSG);
     }
     return;
@@ -75,7 +75,7 @@ export const validateOptionsWarnings = (options?: HoneycombOptions) => {
   }
 
   // warn if custom sampler provided
-  if (options?.sampler && logLevel === DiagLogLevel.DEBUG) {
+  if (options?.sampler && logLevel >= DiagLogLevel.DEBUG) {
     console.debug(SAMPLER_OVERRIDE_WARNING);
   }
 

--- a/packages/honeycomb-opentelemetry-web/src/validate-options.ts
+++ b/packages/honeycomb-opentelemetry-web/src/validate-options.ts
@@ -1,4 +1,4 @@
-import { HoneycombOptions } from './types';
+import { HoneycombOptions, LogLevel } from './types';
 import {
   createHoneycombSDKLogMessage,
   defaultOptions,
@@ -32,17 +32,10 @@ export const FAILED_AUTH_FOR_LOCAL_VISUALIZATIONS =
     '🔕 Failed to get proper auth response from Honeycomb. No local visualization available.',
   );
 
-enum LogLevel {
-  DEBUG,
-  INFO,
-  WARN,
-  ERROR,
-}
-
 export const validateOptionsWarnings = (options?: HoneycombOptions) => {
   const logLevel = options?.logLevel
     ? LogLevel[options.logLevel]
-    : LogLevel.INFO;
+    : LogLevel.DEBUG;
 
   if (options?.skipOptionsValidation) {
     if (logLevel === LogLevel.DEBUG) {

--- a/packages/honeycomb-opentelemetry-web/src/validate-options.ts
+++ b/packages/honeycomb-opentelemetry-web/src/validate-options.ts
@@ -1,4 +1,5 @@
-import { HoneycombOptions, LogLevel } from './types';
+import { DiagLogLevel } from '@opentelemetry/api';
+import { HoneycombOptions } from './types';
 import {
   createHoneycombSDKLogMessage,
   defaultOptions,
@@ -33,23 +34,24 @@ export const FAILED_AUTH_FOR_LOCAL_VISUALIZATIONS =
   );
 
 export const validateOptionsWarnings = (options?: HoneycombOptions) => {
-  const logLevel = options?.logLevel
-    ? LogLevel[options.logLevel]
-    : LogLevel.DEBUG;
+  const logLevel: DiagLogLevel = options?.logLevel
+    ? options.logLevel
+    : DiagLogLevel.DEBUG;
+  console.log('logLevel:', logLevel);
 
   if (options?.skipOptionsValidation) {
-    if (logLevel === LogLevel.DEBUG) {
+    if (logLevel === DiagLogLevel.DEBUG) {
       console.debug(SKIPPING_OPTIONS_VALIDATION_MSG);
     }
     return;
   }
   // warn if api key is missing
-  if (!options?.apiKey && logLevel <= LogLevel.WARN) {
+  if (!options?.apiKey && logLevel >= DiagLogLevel.WARN) {
     console.warn(MISSING_API_KEY_ERROR);
   }
 
   // warn if service name is missing
-  if (!options?.serviceName && logLevel <= LogLevel.WARN) {
+  if (!options?.serviceName && logLevel >= DiagLogLevel.WARN) {
     console.warn(MISSING_SERVICE_NAME_ERROR);
   }
 
@@ -58,7 +60,7 @@ export const validateOptionsWarnings = (options?: HoneycombOptions) => {
     options?.apiKey &&
     !isClassic(options?.apiKey) &&
     options?.dataset &&
-    logLevel <= LogLevel.WARN
+    logLevel >= DiagLogLevel.WARN
   ) {
     console.warn(IGNORED_DATASET_ERROR);
   }
@@ -68,13 +70,13 @@ export const validateOptionsWarnings = (options?: HoneycombOptions) => {
     options?.apiKey &&
     isClassic(options?.apiKey) &&
     !options?.dataset &&
-    logLevel <= LogLevel.WARN
+    logLevel >= DiagLogLevel.WARN
   ) {
     console.warn(MISSING_DATASET_ERROR);
   }
 
   // warn if custom sampler provided
-  if (options?.sampler && logLevel === LogLevel.DEBUG) {
+  if (options?.sampler && logLevel === DiagLogLevel.DEBUG) {
     console.debug(SAMPLER_OVERRIDE_WARNING);
   }
 

--- a/packages/honeycomb-opentelemetry-web/test/validate-options.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/validate-options.test.ts
@@ -1,3 +1,4 @@
+import { DiagLogLevel } from '@opentelemetry/api';
 import { HoneycombWebSDK } from '../src/honeycomb-otel-sdk';
 import {
   IGNORED_DATASET_ERROR,
@@ -46,7 +47,7 @@ describe('console warnings', () => {
     it('should not show any warnings or debug logs if log level is higher than debug level', () => {
       new HoneycombWebSDK({
         skipOptionsValidation: true,
-        logLevel: 'INFO',
+        logLevel: DiagLogLevel.INFO,
       });
       expect(debugSpy).not.toHaveBeenCalled();
     });
@@ -54,7 +55,7 @@ describe('console warnings', () => {
     it("should show debug logs if log level is 'DEBUG'", () => {
       new HoneycombWebSDK({
         skipOptionsValidation: true,
-        logLevel: 'DEBUG',
+        logLevel: DiagLogLevel.DEBUG,
       });
       expect(debugSpy).toHaveBeenNthCalledWith(
         1,
@@ -106,7 +107,7 @@ describe('console warnings', () => {
 
     it("should not show any warnings if log level is higher than 'WARN'", () => {
       new HoneycombWebSDK({
-        logLevel: 'ERROR',
+        logLevel: DiagLogLevel.ERROR,
       });
 
       expect(warningSpy).not.toHaveBeenCalled();

--- a/packages/honeycomb-opentelemetry-web/test/validate-options.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/validate-options.test.ts
@@ -42,7 +42,27 @@ describe('console warnings', () => {
         SKIPPING_OPTIONS_VALIDATION_MSG,
       );
     });
+
+    it('should not show any warnings or debug logs if log level is higher than debug level', () => {
+      new HoneycombWebSDK({
+        skipOptionsValidation: true,
+        logLevel: 'INFO',
+      });
+      expect(debugSpy).not.toHaveBeenCalled();
+    });
+
+    it("should show debug logs if log level is 'DEBUG'", () => {
+      new HoneycombWebSDK({
+        skipOptionsValidation: true,
+        logLevel: 'DEBUG',
+      });
+      expect(debugSpy).toHaveBeenNthCalledWith(
+        1,
+        SKIPPING_OPTIONS_VALIDATION_MSG,
+      );
+    });
   });
+
   describe('when skipOptionsValidation is false', () => {
     it('should show the API key missing warning', () => {
       new HoneycombWebSDK({
@@ -82,6 +102,14 @@ describe('console warnings', () => {
       });
 
       expect(debugSpy).toHaveBeenLastCalledWith(SAMPLER_OVERRIDE_WARNING);
+    });
+
+    it("should not show any warnings if log level is higher than 'WARN'", () => {
+      new HoneycombWebSDK({
+        logLevel: 'ERROR',
+      });
+
+      expect(warningSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/honeycomb-opentelemetry-web/test/validate-options.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/validate-options.test.ts
@@ -44,7 +44,7 @@ describe('console warnings', () => {
       );
     });
 
-    it('should not show any warnings or debug logs if log level is higher than debug level', () => {
+    it('should not show any warnings or debug logs if log level is lower than DEBUG level', () => {
       new HoneycombWebSDK({
         skipOptionsValidation: true,
         logLevel: DiagLogLevel.INFO,
@@ -105,7 +105,7 @@ describe('console warnings', () => {
       expect(debugSpy).toHaveBeenLastCalledWith(SAMPLER_OVERRIDE_WARNING);
     });
 
-    it("should not show any warnings if log level is higher than 'WARN'", () => {
+    it("should not show any warnings if log level is lower than 'WARN'", () => {
       new HoneycombWebSDK({
         logLevel: DiagLogLevel.ERROR,
       });


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #279

## Short description of the changes

Users will now have the option to set a log level when initializing the SDK. This log level controls the verbosity of logs outputted. The current log levels includes DEBUG, INFO, WARN, and ERROR.

## How to verify that this has the expected result
- Unit tests have been added
- I tested locally by reproducing the issue and seeing if my changes fixed the issue
