### PR TITLE
feat: Allow Disabling the default Exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Pass these options to the HoneycombWebSDK:
 | skipOptionsValidation | optional                                         | boolean | false                   | Do not require any fields.[*](#send-to-an-opentelemetry-collector) Use with OpenTelemetry Collector.                                                                                                       |
 | spanProcessors | optional                                         | SpanProcessor[] | | Array of [span processors](https://opentelemetry.io/docs/languages/java/instrumentation/#span-processor) to apply to all generated spans.  |
 | traceExporters | optional                                         | SpanExporter[] | | Array of [span exporters](https://opentelemetry.io/docs/languages/js/exporters) | optional |
-| disableDefaultTraceExporter | optional                                    | boolean | false                   | Disable default honeycomb trace exporter (you must provide an alternative exporter) |
+| disableDefaultTraceExporter | optional                                    | boolean | false                   | Disable default honeycomb trace exporter. You can provide additional exporters via `traceExporters` config option.  |
 |  webVitalsInstrumentationConfig|optional|WebVitalsInstrumentationConfig| `{ enabled: true }` | See [WebVitalsInstrumentationConfig](####WebVitalsInstrumentationConfig). |
 |  globalErrorsInstrumentationConfig |optional| GlobalErrorsInstrumentationConfig|  `{ enabled: true }` | See [GlobalErrorsInstrumentationConfig](####GlobalErrorsInstrumentationConfig).
 | logLevel              | optional                                    | DiagLogLevel | DiagLogLevel.DEBUG       | Controls the verbosity of logs printed to the console. |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Pass these options to the HoneycombWebSDK:
 | skipOptionsValidation | optional                                         | boolean | false                   | Do not require any fields.[*](#send-to-an-opentelemetry-collector) Use with OpenTelemetry Collector.                                                                                                       |
 | spanProcessors | optional                                         | SpanProcessor[] | | Array of [span processors](https://opentelemetry.io/docs/languages/java/instrumentation/#span-processor) to apply to all generated spans.  |
 | traceExporters | optional                                         | SpanExporter[] | | Array of [span exporters](https://opentelemetry.io/docs/languages/js/exporters) | optional |
+| disableDefaultTraceExporter | optional                                    | boolean | false                   | Disable default honeycomb trace exporter (you must provide an alternative exporter) |
 |  webVitalsInstrumentationConfig|optional|WebVitalsInstrumentationConfig| `{ enabled: true }` | See [WebVitalsInstrumentationConfig](####WebVitalsInstrumentationConfig). |
 |  globalErrorsInstrumentationConfig |optional| GlobalErrorsInstrumentationConfig|  `{ enabled: true }` | See [GlobalErrorsInstrumentationConfig](####GlobalErrorsInstrumentationConfig).
 | logLevel              | optional                                    | DiagLogLevel | DiagLogLevel.DEBUG       | Controls the verbosity of logs printed to the console. |

--- a/packages/honeycomb-opentelemetry-web/src/span-processor-builder.ts
+++ b/packages/honeycomb-opentelemetry-web/src/span-processor-builder.ts
@@ -37,14 +37,18 @@ export const configureSpanProcessors = (options?: HoneycombOptions) => {
     honeycombTraceExporters.push(...options.traceExporters);
   }
 
+  // Disable this if a configuration option is present
+  if (options?.disableDefaultTraceExporter !== true) {
+    honeycombTraceExporters.push(
+      configureHoneycombHttpJsonTraceExporter(options),
+    );
+  }
+
   // We have to configure the exporter here because the way the base SDK is setup
   // does not allow having both a `spanProcessor` and `traceExporter` configured.
   honeycombSpanProcessor.addProcessor(
     new BatchSpanProcessor(
-      configureCompositeExporter([
-        configureHoneycombHttpJsonTraceExporter(options),
-        ...honeycombTraceExporters,
-      ]),
+      configureCompositeExporter([...honeycombTraceExporters]),
     ),
   );
 

--- a/packages/honeycomb-opentelemetry-web/src/span-processor-builder.ts
+++ b/packages/honeycomb-opentelemetry-web/src/span-processor-builder.ts
@@ -39,7 +39,7 @@ export const configureSpanProcessors = (options?: HoneycombOptions) => {
 
   // Disable this if a configuration option is present
   if (options?.disableDefaultTraceExporter !== true) {
-    honeycombTraceExporters.push(
+    honeycombTraceExporters.unshift(
       configureHoneycombHttpJsonTraceExporter(options),
     );
   }

--- a/packages/honeycomb-opentelemetry-web/src/types.ts
+++ b/packages/honeycomb-opentelemetry-web/src/types.ts
@@ -95,6 +95,13 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
    */
   traceExporters?: SpanExporter[];
 
+  /** Disable the default honeycomb SpanExporters
+   * `true` Disables the default honeycomb span exporter, `false` enables.
+   * in this case you should provide other exporters in the `traceExporters` field.
+   * Defaults to 'false'.
+   */
+  disableDefaultTraceExporter?: boolean;
+
   /** The sample rate used to determine whether a trace is exported.
    * This must be a whole positive number. Only 1 out of every `sampleRate` traces will be randomly selected to be sent.
    * Set to 0 to drop everything.

--- a/packages/honeycomb-opentelemetry-web/src/validate-options.ts
+++ b/packages/honeycomb-opentelemetry-web/src/validate-options.ts
@@ -33,6 +33,10 @@ export const FAILED_AUTH_FOR_LOCAL_VISUALIZATIONS =
     '🔕 Failed to get proper auth response from Honeycomb. No local visualization available.',
   );
 
+export const NO_EXPORTERS_DISABLED_DEFAULT = createHoneycombSDKLogMessage(
+  '🔕 Default honeycomb exporter disabled but no exporters provided',
+);
+
 export const validateOptionsWarnings = (options?: HoneycombOptions) => {
   const logLevel: DiagLogLevel = options?.logLevel
     ? options.logLevel

--- a/packages/honeycomb-opentelemetry-web/src/validate-options.ts
+++ b/packages/honeycomb-opentelemetry-web/src/validate-options.ts
@@ -83,5 +83,14 @@ export const validateOptionsWarnings = (options?: HoneycombOptions) => {
     console.debug(SAMPLER_OVERRIDE_WARNING);
   }
 
+  // warn if no exporter will be set
+  if (
+    options?.disableDefaultTraceExporter === true &&
+    !options?.traceExporter &&
+    !options?.traceExporters?.length
+  ) {
+    console.warn(NO_EXPORTERS_DISABLED_DEFAULT);
+  }
+
   return options;
 };

--- a/packages/honeycomb-opentelemetry-web/test/validate-options.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/validate-options.test.ts
@@ -5,10 +5,14 @@ import {
   MISSING_API_KEY_ERROR,
   MISSING_DATASET_ERROR,
   MISSING_SERVICE_NAME_ERROR,
+  NO_EXPORTERS_DISABLED_DEFAULT,
   SAMPLER_OVERRIDE_WARNING,
   SKIPPING_OPTIONS_VALIDATION_MSG,
 } from '../src/validate-options';
-import { AlwaysOnSampler } from '@opentelemetry/sdk-trace-base';
+import {
+  AlwaysOnSampler,
+  ConsoleSpanExporter,
+} from '@opentelemetry/sdk-trace-base';
 const debugSpy = jest
   .spyOn(console, 'debug')
   .mockImplementation(() => undefined);
@@ -111,6 +115,48 @@ describe('console warnings', () => {
       });
 
       expect(warningSpy).not.toHaveBeenCalled();
+    });
+  });
+  describe('when the default trace exporter is disabled', () => {
+    describe('and no trace exporters are defined', () => {
+      it('should show a no exporters warning', () => {
+        new HoneycombWebSDK({
+          apiKey,
+          serviceName: ' test-service',
+          disableDefaultTraceExporter: true,
+        });
+
+        expect(warningSpy).toHaveBeenCalledWith(NO_EXPORTERS_DISABLED_DEFAULT);
+      });
+    });
+
+    describe('and traceExporter is defined', () => {
+      it('should not show any warnings', () => {
+        const customExporter = new ConsoleSpanExporter();
+        new HoneycombWebSDK({
+          apiKey,
+          serviceName: 'test-service',
+          disableDefaultTraceExporter: true,
+          traceExporter: customExporter,
+        });
+
+        expect(warningSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('and a traceExporters array is defined', () => {
+      it('should not show any warnings', () => {
+        const customExporter = new ConsoleSpanExporter();
+
+        new HoneycombWebSDK({
+          apiKey,
+          serviceName: 'test-service',
+          disableDefaultTraceExporter: true,
+          traceExporters: [customExporter],
+        });
+
+        expect(warningSpy).not.toHaveBeenCalled();
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We have had a few requests come in asking for the ability to disable the default exporter. This makes it possible through a new property in the configuration.

## Short description of the changes

This adds a new SDK configuration property `disableDefaultTraceExporter` that, when set to true will disable the default exporter.

## How to verify that this has the expected result

Provide this boolean as `true` in an example and note no events are sent to honeycomb.
