### PR TITLE
fix: This code duplicated  not needed.

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -492,7 +492,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
           // dataAttributes is undefined (i.e. send all values as span attributes) OR
           (dataAttributes === undefined ||
             // dataAttributes is specified AND attrName is in dataAttributes (i.e attribute name is in the supplied allowList)
-            (dataAttributes && attrName in dataAttributes))
+            dataAttributes.includes(attrName))
         ) {
           span.setAttribute(
             `${attrPrefix}.element.data.${attrName}`,
@@ -501,16 +501,6 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
         }
       }
     }
-    if (dataAttributes)
-      dataAttributes?.forEach((attrName) => {
-        const attrValue = el.dataset[attrName];
-        if (attrValue !== undefined) {
-          span.setAttribute(
-            `${attrPrefix}.element.data.${attrName}`,
-            attrValue,
-          );
-        }
-      });
 
     if (applyCustomAttributes) {
       applyCustomAttributes(lcp, span);

--- a/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
@@ -434,8 +434,8 @@ describe('Web Vitals Instrumentation Tests', () => {
       expect(exporter.getFinishedSpans().length).toEqual(1);
       const span = exporter.getFinishedSpans()[0];
       expect(span.attributes['lcp.element.data.answer']).toEqual('42');
-      expect(span.attributes['lcp.element.famousCats']).toBeUndefined();
-      expect(span.attributes['lcp.element.hasCats']).toBeUndefined();
+      expect(span.attributes['lcp.element.data.famousCats']).toBeUndefined();
+      expect(span.attributes['lcp.element.data.hasCats']).toBeUndefined();
       expect(span.attributes).toMatchObject({
         'lcp.element.data.answer': '42',
       });


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes
This is the original implementation for adding data attributes. it was not removed we updated to use the `dataset` API.

## How to verify that this has the expected result
Use the test apps to ensure that the data attributes are still being attached to spans.