### PR TITLE
fix(honeycomb-opentelemetry-web): Add check for lcpEntry.element

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -483,7 +483,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
     });
 
     const el: HTMLElement = lcpEntry?.element as HTMLElement;
-    if (el.dataset) {
+    if (el?.dataset) {
       for (const attrName in el.dataset) {
         const attrValue = el.dataset[attrName];
         if (


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Sometimes `lcpEntry.element` is null or undefined, this check prevents an `Cannot read properties of undefined (reading 'dataset')` error.

## How to verify that this has the expected result
