### PR TITLE
fix(rollup): Remove x64 specific package

### DIFF
--- a/packages/experimental-opentelemetry-web/package-lock.json
+++ b/packages/experimental-opentelemetry-web/package-lock.json
@@ -55,9 +55,6 @@
         "ts-jest": "^29.2.5",
         "tslib": "^2.7.0",
         "typescript": "^5.4.5"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.21.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3428,6 +3425,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"

--- a/packages/experimental-opentelemetry-web/package.json
+++ b/packages/experimental-opentelemetry-web/package.json
@@ -82,8 +82,5 @@
     "shimmer": "^1.2.1",
     "ua-parser-js": "^1.0.39",
     "web-vitals": "^4.2.3"
-  },
-  "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.21.2"
   }
 }

--- a/packages/honeycomb-opentelemetry-web/package-lock.json
+++ b/packages/honeycomb-opentelemetry-web/package-lock.json
@@ -20,7 +20,6 @@
         "@opentelemetry/sdk-trace-base": "~1.27.0",
         "@opentelemetry/sdk-trace-web": "~1.27.0",
         "@opentelemetry/semantic-conventions": "~1.27.0",
-        "@rollup/rollup-linux-x64-gnu": "^4.9.5",
         "shimmer": "^1.2.1",
         "ua-parser-js": "^1.0.37",
         "web-vitals": "^4.2.3"
@@ -59,9 +58,6 @@
         "ts-jest": "^29.1.2",
         "tslib": "^2.6.3",
         "typescript": "^5.4.5"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.9.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4079,18 +4075,6 @@
         "s390x"
       ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.4.tgz",
-      "integrity": "sha512-K03TljaaoPK5FOyNMZAAEmhlyO49LaE4qCsr0lYHUKyb6QacTNF9pnfPpXnFlFD3TXuFbFbz7tJ51FujUXkXYA==",
-      "cpu": [
-        "x64"
-      ],
       "optional": true,
       "os": [
         "linux"

--- a/packages/honeycomb-opentelemetry-web/package.json
+++ b/packages/honeycomb-opentelemetry-web/package.json
@@ -88,8 +88,5 @@
     "shimmer": "^1.2.1",
     "ua-parser-js": "^1.0.37",
     "web-vitals": "^4.2.3"
-  },
-  "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.9.5"
   }
 }


### PR DESCRIPTION
## Short description of the changes

Removes installing the arch specific package of rollup

## How to verify that this has the expected result

the build passes