### PR TITLE
feat: Add additional fields collected by the TraceKit package for stack traces

### DIFF
--- a/packages/honeycomb-opentelemetry-web/package-lock.json
+++ b/packages/honeycomb-opentelemetry-web/package-lock.json
@@ -21,6 +21,7 @@
         "@opentelemetry/sdk-trace-web": "~1.27.0",
         "@opentelemetry/semantic-conventions": "~1.27.0",
         "shimmer": "^1.2.1",
+        "tracekit": "^0.4.7",
         "ua-parser-js": "^1.0.37",
         "web-vitals": "^4.2.3"
       },
@@ -14254,6 +14255,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/tracekit": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/tracekit/-/tracekit-0.4.7.tgz",
+      "integrity": "sha512-d3BLRambfZ0VOYLIh7FRSElugsOMrNgxzT4jXyOXC7lnhoeEJIHNg8VAcpKVVmu9kREGUAVg8Eh3SlRfkU/ksQ==",
+      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",

--- a/packages/honeycomb-opentelemetry-web/package.json
+++ b/packages/honeycomb-opentelemetry-web/package.json
@@ -86,6 +86,7 @@
     "@opentelemetry/sdk-trace-web": "~1.27.0",
     "@opentelemetry/semantic-conventions": "~1.27.0",
     "shimmer": "^1.2.1",
+    "tracekit": "^0.4.7",
     "ua-parser-js": "^1.0.37",
     "web-vitals": "^4.2.3"
   }

--- a/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
@@ -33,6 +33,7 @@ describe('Global Errors Instrumentation Tests', () => {
 
       const span = exporter.getFinishedSpans()[0];
       expect(span.name).toBe('exception');
+      // TODO: Mock a stack trace and test that it returns the correct keys and values
       expect(span.attributes).toMatchObject({
         'exception.type': 'Error',
         'exception.message': 'Something happened',
@@ -70,6 +71,7 @@ describe('Global Errors Instrumentation Tests', () => {
       expect(instr._computeStackTrace(undefined)).toEqual({});
     });
 
+    // TODO: Mock a stack trace and test that it returns the correct keys and values
     it('should return an object with structured stack trace information', () => {
       expect(instr._computeStackTrace(new Error('This is an error'))).toEqual({
         'exception.structured_stacktrace.columns': expect.any(Array),

--- a/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
@@ -65,7 +65,7 @@ describe('Global Errors Instrumentation Tests', () => {
     });
   });
 
-  describe('computeStackTrace', () => {
+  describe('_computeStackTrace', () => {
     it('should return an empty object if error is undefined', () => {
       expect(instr._computeStackTrace(undefined)).toEqual({});
     });

--- a/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
@@ -5,7 +5,6 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import { GlobalErrorsInstrumentation } from '../src/global-errors-autoinstrumentation';
 import timers from 'node:timers/promises';
-import { Attributes } from '@opentelemetry/api';
 
 describe('Global Errors Instrumentation Tests', () => {
   const exporter = new InMemorySpanExporter();
@@ -66,6 +65,3 @@ describe('Global Errors Instrumentation Tests', () => {
     });
   });
 });
-function expect(attributes: Attributes) {
-  throw new Error('Function not implemented.');
-}

--- a/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import { GlobalErrorsInstrumentation } from '../src/global-errors-autoinstrumentation';
 import timers from 'node:timers/promises';
+import { Attributes } from '@opentelemetry/api';
 
 describe('Global Errors Instrumentation Tests', () => {
   const exporter = new InMemorySpanExporter();
@@ -37,6 +38,10 @@ describe('Global Errors Instrumentation Tests', () => {
         'exception.type': 'Error',
         'exception.message': 'Something happened',
         'exception.stacktrace': expect.any(String),
+        'exception.structured_stacktrace.columns': expect.any(Array),
+        'exception.structured_stacktrace.lines': expect.any(Array),
+        'exception.structured_stacktrace.functions': expect.any(Array),
+        'exception.structured_stacktrace.urls': expect.any(Array),
       });
     });
 
@@ -61,3 +66,6 @@ describe('Global Errors Instrumentation Tests', () => {
     });
   });
 });
+function expect(attributes: Attributes) {
+  throw new Error('Function not implemented.');
+}

--- a/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
@@ -64,4 +64,19 @@ describe('Global Errors Instrumentation Tests', () => {
       });
     });
   });
+
+  describe('computeStackTrace', () => {
+    it('should return an empty object if error is undefined', () => {
+      expect(instr._computeStackTrace(undefined)).toEqual({});
+    });
+
+    it('should return an object with structured stack trace information', () => {
+      expect(instr._computeStackTrace(new Error('This is an error'))).toEqual({
+        'exception.structured_stacktrace.columns': expect.any(Array),
+        'exception.structured_stacktrace.lines': expect.any(Array),
+        'exception.structured_stacktrace.functions': expect.any(Array),
+        'exception.structured_stacktrace.urls': expect.any(Array),
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes

Introduces the [TraceKit](https://github.com/csnover/TraceKit) package to the web distro. Adds additional fields with the help of the `TraceKit` package. These additional fields are prefixed with `exception.structured_stacktrace`. Additional fields will be sent by `GlobalErrorsInstrumentation`.

## How to verify that this has the expected result
I tested locally using the `hello-world-web` example provided by the web-distro. Made the example to throw a simple error. This was the result I received on Honeycomb:

<img width="848" alt="Screenshot 2024-11-07 at 3 34 27 PM" src="https://github.com/user-attachments/assets/ac6cc8ac-2cf6-47e5-b4fa-4d21d466c160">

Big thanks to @pkanal for helping with this change!

