### PR TITLE
feat: Update tests to use mocked stacktrace

### DIFF
--- a/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
@@ -26,22 +26,35 @@ describe('Global Errors Instrumentation Tests', () => {
 
   describe('when enabled', () => {
     it('should create a span when an error escapes', async () => {
+      const err = new Error('Something happened');
+      err.stack =
+        '' +
+        '  Error: Something happened\n' +
+        '    at baz (filename.js:10:15)\n' +
+        '    at bar (filename.js:6:3)\n' +
+        '    at foo (filename.js:2:3)\n' +
+        '    at (filename.js:13:1)';
       setTimeout(() => {
-        throw new Error('Something happened');
+        throw err;
       });
       await timers.setTimeout();
 
       const span = exporter.getFinishedSpans()[0];
       expect(span.name).toBe('exception');
       // TODO: Mock a stack trace and test that it returns the correct keys and values
-      expect(span.attributes).toMatchObject({
+      expect(span.attributes).toEqual({
         'exception.type': 'Error',
         'exception.message': 'Something happened',
-        'exception.stacktrace': expect.any(String),
-        'exception.structured_stacktrace.columns': expect.any(Array),
-        'exception.structured_stacktrace.lines': expect.any(Array),
-        'exception.structured_stacktrace.functions': expect.any(Array),
-        'exception.structured_stacktrace.urls': expect.any(Array),
+        'exception.stacktrace': err.stack,
+        'exception.structured_stacktrace.columns': [15, 3, 3, 1],
+        'exception.structured_stacktrace.lines': [10, 6, 2, 13],
+        'exception.structured_stacktrace.functions': ['baz', 'bar', 'foo', '?'],
+        'exception.structured_stacktrace.urls': [
+          'filename.js',
+          'filename.js',
+          'filename.js',
+          'filename.js',
+        ],
       });
     });
 
@@ -71,14 +84,65 @@ describe('Global Errors Instrumentation Tests', () => {
       expect(instr._computeStackTrace(undefined)).toEqual({});
     });
 
-    // TODO: Mock a stack trace and test that it returns the correct keys and values
     it('should return an object with structured stack trace information', () => {
-      expect(instr._computeStackTrace(new Error('This is an error'))).toEqual({
-        'exception.structured_stacktrace.columns': expect.any(Array),
-        'exception.structured_stacktrace.lines': expect.any(Array),
-        'exception.structured_stacktrace.functions': expect.any(Array),
-        'exception.structured_stacktrace.urls': expect.any(Array),
+      const err = new Error('This is an error');
+      err.stack =
+        '' +
+        '  Error: This is an error\n' +
+        '    at new <anonymous> (http://example.com/js/test.js:63:1)\n' + // stack frame 0
+        '    at namedFunc0 (http://example.com/js/script.js:10:2)\n' + // stack frame 1
+        '    at http://example.com/js/test.js:65:10\n' + // stack frame 2
+        '    at new Promise (<anonymous>)\n' + // stack frame 3
+        '    at namedFunc2 (http://example.com/js/script.js:20:5)\n' + // stack frame 4
+        '    at http://example.com/js/test.js:67:5\n' + // stack frame 5
+        '    at namedFunc4 (http://example.com/js/script.js:100001:10002)'; // stack frame 6
+
+      const structuredStack = instr._computeStackTrace(err);
+
+      expect(structuredStack).toEqual({
+        'exception.structured_stacktrace.columns': [
+          1,
+          2,
+          10,
+          null,
+          5,
+          5,
+          10002,
+        ],
+        'exception.structured_stacktrace.lines': [
+          63,
+          10,
+          65,
+          null,
+          20,
+          67,
+          100001,
+        ],
+        'exception.structured_stacktrace.functions': [
+          'new <anonymous>',
+          'namedFunc0',
+          '?',
+          'new Promise',
+          'namedFunc2',
+          '?',
+          'namedFunc4',
+        ],
+        'exception.structured_stacktrace.urls': [
+          'http://example.com/js/test.js',
+          'http://example.com/js/script.js',
+          'http://example.com/js/test.js',
+          '<anonymous>',
+          'http://example.com/js/script.js',
+          'http://example.com/js/test.js',
+          'http://example.com/js/script.js',
+        ],
       });
+
+      expect(
+        structuredStack['exception.structured_stacktrace.columns']?.length,
+      ).toEqual(
+        structuredStack['exception.structured_stacktrace.lines']?.length,
+      );
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes
Mocks a stack trace that is passed to our `_computeStackTrace` function so we can test with actual values.

## How to verify that this has the expected result
All tests pass!
