### PR TITLE
fix: Fix TTFB and FCP metrics not appearing

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -253,7 +253,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
 
   constructor({
     enabled = true,
-    vitalsToTrack = ['CLS', 'LCP', 'INP'],
+    vitalsToTrack = ['CLS', 'LCP', 'INP', 'TTFB', 'FCP'],
     lcp,
     cls,
     inp,

--- a/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
@@ -630,14 +630,14 @@ describe('Web Vitals Instrumentation Tests', () => {
   });
 
   describe('config.vitalsToTrack', () => {
-    it(`should default to ['CLS', 'LCP', 'INP'] when an empty config`, () => {
+    it(`should default to ['CLS', 'LCP', 'INP', 'TTFB', 'FCP'] when an empty config`, () => {
       const instr = new WebVitalsInstrumentation();
-      expect(instr.vitalsToTrack).toEqual(['CLS', 'LCP', 'INP']);
+      expect(instr.vitalsToTrack).toEqual(['CLS', 'LCP', 'INP', 'TTFB', 'FCP']);
     });
 
-    it(`should default to ['CLS', 'LCP', 'INP'] when OTHER configuration options`, () => {
+    it(`should default to ['CLS', 'LCP', 'INP', 'TTFB', 'FCP'] when OTHER configuration options`, () => {
       const instr = new WebVitalsInstrumentation({ enabled: false });
-      expect(instr.vitalsToTrack).toEqual(['CLS', 'LCP', 'INP']);
+      expect(instr.vitalsToTrack).toEqual(['CLS', 'LCP', 'INP', 'TTFB', 'FCP']);
     });
 
     it('should be overridden vitalsToTrack is explicity passed', () => {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->
## Short description of the changes

TTFB, FCP, and FID metrics were not appearing unless you explicitly include them in the `vitalsToTrack` config option. Including TTFB and FID as default vitals to track. Leaving FID out since it is deprecated and will be unsupported soon.

## How to verify that this has the expected result

- Test with a basic Web SDK config without defining the `vitalsToTrack` config option
-  TTFB and FID metrics should now be sent
