### PR TITLE
feat(honeycomb-opentelemetry-web): Add support for differing subdomains for debug link exporter.

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/console-trace-link-exporter.ts
+++ b/packages/honeycomb-opentelemetry-web/src/console-trace-link-exporter.ts
@@ -36,7 +36,7 @@ export function configureConsoleTraceLinkExporter(
 
 export const getUrlRoots = (endpoint = '') => {
   const url = new URL(endpoint);
-  const subdomainRegex = /(api)([.|-])?(.*?)(\.?)(honeycomb.io)(.*)/;
+  const subdomainRegex = /(api)([.|-])?(.*?)(\.?)(honeycomb\.io)(.*)/;
   const matches = subdomainRegex.exec(url.host);
   if (matches === null) {
     return {

--- a/packages/honeycomb-opentelemetry-web/src/honeycomb-otel-sdk.ts
+++ b/packages/honeycomb-opentelemetry-web/src/honeycomb-otel-sdk.ts
@@ -27,7 +27,8 @@ export class HoneycombWebSDK extends WebSDK {
           options?.globalErrorsInstrumentationConfig,
         ),
       );
-    }``
+    }
+    ``;
 
     super({
       ...options,

--- a/packages/honeycomb-opentelemetry-web/src/honeycomb-otel-sdk.ts
+++ b/packages/honeycomb-opentelemetry-web/src/honeycomb-otel-sdk.ts
@@ -27,7 +27,7 @@ export class HoneycombWebSDK extends WebSDK {
           options?.globalErrorsInstrumentationConfig,
         ),
       );
-    }
+    }``
 
     super({
       ...options,

--- a/packages/honeycomb-opentelemetry-web/src/honeycomb-otel-sdk.ts
+++ b/packages/honeycomb-opentelemetry-web/src/honeycomb-otel-sdk.ts
@@ -28,7 +28,6 @@ export class HoneycombWebSDK extends WebSDK {
         ),
       );
     }
-    ``;
 
     super({
       ...options,

--- a/packages/honeycomb-opentelemetry-web/src/validate-options.ts
+++ b/packages/honeycomb-opentelemetry-web/src/validate-options.ts
@@ -28,6 +28,9 @@ export const MISSING_FIELDS_FOR_LOCAL_VISUALIZATIONS =
   createHoneycombSDKLogMessage(
     '🔕 Disabling local visualizations - must have both service name and API key configured.',
   );
+export const MISSING_FIELDS_FOR_GENERATING_LINKS = createHoneycombSDKLogMessage(
+  '🔕 Disabling local visualizations - cannot infer auth and ui url roots from endpoint url.',
+);
 export const FAILED_AUTH_FOR_LOCAL_VISUALIZATIONS =
   createHoneycombSDKLogMessage(
     '🔕 Failed to get proper auth response from Honeycomb. No local visualization available.',

--- a/packages/honeycomb-opentelemetry-web/test/console-trace-link-exporter.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/console-trace-link-exporter.test.ts
@@ -2,6 +2,7 @@ import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import {
   buildTraceUrl,
   configureConsoleTraceLinkExporter,
+  getUrlRoots,
 } from '../src/console-trace-link-exporter';
 
 const apikey = '000000000000000000000000';
@@ -14,6 +15,7 @@ describe('buildTraceUrl', () => {
       'my-service',
       'my-team',
       'my-environment',
+      'https://ui.honeycomb.io',
     );
     expect(url).toBe(
       'https://ui.honeycomb.io/my-team/environments/my-environment/datasets/my-service/trace?trace_id',
@@ -26,6 +28,7 @@ describe('buildTraceUrl', () => {
       'my-service',
       'my-team',
       'my-environment',
+      'https://ui.honeycomb.io',
     );
     expect(url).toBe(
       'https://ui.honeycomb.io/my-team/datasets/my-service/trace?trace_id',
@@ -64,6 +67,7 @@ describe('ConsoleTraceLinkExporter', () => {
     const exporter = configureConsoleTraceLinkExporter({
       apiKey: apikey,
       serviceName: 'test-service',
+      endpoint: 'https://api.honeycomb.io/v1/traces',
     });
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -105,6 +109,7 @@ describe('ConsoleTraceLinkExporter', () => {
     const exporter = configureConsoleTraceLinkExporter({
       apiKey: apikey,
       serviceName: 'test-service',
+      endpoint: 'https://api.honeycomb.io/v1/traces',
     });
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -144,6 +149,7 @@ describe('ConsoleTraceLinkExporter', () => {
     const exporter = configureConsoleTraceLinkExporter({
       apiKey: apikey,
       serviceName: 'test-service',
+      endpoint: 'https://api.honeycomb.io/v1/traces',
     });
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -175,5 +181,35 @@ describe('ConsoleTraceLinkExporter', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith(
       '@honeycombio/opentelemetry-web: 🔕 Failed to get proper auth response from Honeycomb. No local visualization available.',
     );
+  });
+});
+
+describe('getUrlRoots', () => {
+  it('it should generate correct auth and ui url roots for domains (api.)', () => {
+    const endpoint = 'https://api.honeycomb.io/v1/traces';
+    const { authRoot, uiRoot } = getUrlRoots(endpoint);
+    expect(authRoot).toEqual('https://api.honeycomb.io/1/auth');
+    expect(uiRoot).toEqual('https://ui.honeycomb.io');
+  });
+  it('it should generate correct auth and ui url roots for dash-separated domains domains (api-other_env.)', () => {
+    const endpoint = 'https://api-other_env.honeycomb.io/v1/traces';
+    const { authRoot, uiRoot } = getUrlRoots(endpoint);
+    expect(authRoot).toEqual('https://api-other_env.honeycomb.io/1/auth');
+    expect(uiRoot).toEqual('https://ui-other_env.honeycomb.io');
+  });
+  it('it should generate correct auth and ui url roots for dot-separated domains (api.other_region)', () => {
+    const endpoint = 'https://api.other_region.honeycomb.io/v1/traces';
+    const { authRoot, uiRoot } = getUrlRoots(endpoint);
+    expect(authRoot).toEqual('https://api.other_region.honeycomb.io/1/auth');
+    expect(uiRoot).toEqual('https://ui.other_region.honeycomb.io');
+  });
+  it('it should generate correct auth and ui url roots for dot-dash-separated domains (api.other_env-other_region.)', () => {
+    const endpoint =
+      'https://api.other_env-other_region.honeycomb.io/v1/traces';
+    const { authRoot, uiRoot } = getUrlRoots(endpoint);
+    expect(authRoot).toEqual(
+      'https://api.other_env-other_region.honeycomb.io/1/auth',
+    );
+    expect(uiRoot).toEqual('https://ui.other_env-other_region.honeycomb.io');
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
This will enable this to work with EU deployments. 

## Short description of the changes
Infers the ui and auth URL roots from the supplied `endpoint`.

## How to verify that this has the expected result
Pointing an example app to `https://api.eu1.honeycomb.io/v1/traces` as suggested in the sample apps should link to EU traces. 