### PR TITLE
feat: Add `recordException` helper function

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/global-errors-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/global-errors-autoinstrumentation.ts
@@ -47,7 +47,7 @@ export function getStructuredStackTrace(error: Error | undefined) {
 
 export function recordException(
   error: Error,
-  attributes: Attributes,
+  attributes: Attributes = {},
   tracer: Tracer = trace.getTracer(LIBRARY_NAME),
 ) {
   const message = error.message;

--- a/packages/honeycomb-opentelemetry-web/src/global-errors-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/global-errors-autoinstrumentation.ts
@@ -1,13 +1,74 @@
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { InstrumentationAbstract } from './web-vitals-autoinstrumentation';
 import { VERSION } from './version';
-import { context, SpanStatusCode } from '@opentelemetry/api';
 import {
-  SEMATTRS_EXCEPTION_MESSAGE,
-  SEMATTRS_EXCEPTION_STACKTRACE,
-  SEMATTRS_EXCEPTION_TYPE,
+  Attributes,
+  context,
+  SpanStatusCode,
+  trace,
+  Tracer,
+} from '@opentelemetry/api';
+import {
+  ATTR_EXCEPTION_MESSAGE,
+  ATTR_EXCEPTION_STACKTRACE,
+  ATTR_EXCEPTION_TYPE,
 } from '@opentelemetry/semantic-conventions';
 import { computeStackTrace, StackFrame } from 'tracekit';
+
+const LIBRARY_NAME = '@honeycombio/instrumentation-global-errors';
+
+export function getStructuredStackTrace(error: Error | undefined) {
+  if (!error) {
+    return {};
+  }
+
+  // OTLP does not accept arrays of objects
+  // breaking down the stack into arrays of strings/numbers
+  const structuredStack: StackFrame[] = computeStackTrace(error).stack;
+  const lines: number[] = [];
+  const columns: number[] = [];
+  const functions: string[] = [];
+  const urls: string[] = [];
+
+  for (const stackFrame of structuredStack) {
+    lines.push(stackFrame.line);
+    columns.push(stackFrame.column);
+    functions.push(stackFrame.func);
+    urls.push(stackFrame.url);
+  }
+
+  return {
+    'exception.structured_stacktrace.columns': columns,
+    'exception.structured_stacktrace.lines': lines,
+    'exception.structured_stacktrace.functions': functions,
+    'exception.structured_stacktrace.urls': urls,
+  };
+}
+
+export function recordException(
+  error: Error,
+  attributes: Attributes,
+  tracer: Tracer = trace.getTracer(LIBRARY_NAME),
+) {
+  const message = error.message;
+  const type = error.name;
+  const errorAttributes = {
+    [ATTR_EXCEPTION_TYPE]: type,
+    [ATTR_EXCEPTION_MESSAGE]: message,
+    [ATTR_EXCEPTION_STACKTRACE]: error.stack,
+    ...getStructuredStackTrace(error),
+    ...attributes,
+  };
+
+  const errorSpan = tracer.startSpan(
+    'exception',
+    { attributes: errorAttributes },
+    context.active(),
+  );
+
+  errorSpan.setStatus({ code: SpanStatusCode.ERROR, message });
+  errorSpan.end();
+}
 
 export interface GlobalErrorsInstrumentationConfig
   extends InstrumentationConfig {}
@@ -20,61 +81,19 @@ export class GlobalErrorsInstrumentation extends InstrumentationAbstract {
   private _isEnabled: boolean;
   constructor({ enabled = true }: GlobalErrorsInstrumentationConfig = {}) {
     const config: GlobalErrorsInstrumentationConfig = { enabled };
-    super('@honeycombio/instrumentation-global-errors', VERSION, config);
+    super(LIBRARY_NAME, VERSION, config);
     if (enabled) {
       this.enable();
     }
     this._isEnabled = enabled;
   }
 
-  _computeStackTrace = (error: Error | undefined) => {
-    if (!error) {
-      return {};
-    }
-
-    // OTLP does not accept arrays of objects
-    // breaking down the stack into arrays of strings/numbers
-    const structuredStack: StackFrame[] = computeStackTrace(error).stack;
-    const lines: number[] = [];
-    const columns: number[] = [];
-    const functions: string[] = [];
-    const urls: string[] = [];
-
-    for (const stackFrame of structuredStack) {
-      lines.push(stackFrame.line);
-      columns.push(stackFrame.column);
-      functions.push(stackFrame.func);
-      urls.push(stackFrame.url);
-    }
-
-    return {
-      'exception.structured_stacktrace.columns': columns,
-      'exception.structured_stacktrace.lines': lines,
-      'exception.structured_stacktrace.functions': functions,
-      'exception.structured_stacktrace.urls': urls,
-    };
-  };
-
   onError = (event: ErrorEvent | PromiseRejectionEvent) => {
     const error: Error | undefined =
       'reason' in event ? event.reason : event.error;
-    const message = error?.message;
-    const type = error?.name;
-    const attributes = {
-      [SEMATTRS_EXCEPTION_TYPE]: type,
-      [SEMATTRS_EXCEPTION_MESSAGE]: message,
-      [SEMATTRS_EXCEPTION_STACKTRACE]: error?.stack,
-      ...this._computeStackTrace(error),
-    };
-    // otel spec requires at minimum these two
-    if (!message || !type) return;
-    const errorSpan = this.tracer.startSpan(
-      'exception',
-      { attributes },
-      context.active(),
-    );
-    errorSpan.setStatus({ code: SpanStatusCode.ERROR, message });
-    errorSpan.end();
+    if (error) {
+      recordException(error, {}, this.tracer);
+    }
   };
 
   init() {}

--- a/packages/honeycomb-opentelemetry-web/src/index.ts
+++ b/packages/honeycomb-opentelemetry-web/src/index.ts
@@ -1,3 +1,4 @@
 export * from './base-otel-sdk';
 export * from './honeycomb-otel-sdk';
 export * from './web-vitals-autoinstrumentation';
+export * from './global-errors-autoinstrumentation';

--- a/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/global-errors-instrumentation.test.ts
@@ -3,7 +3,10 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
-import { GlobalErrorsInstrumentation } from '../src/global-errors-autoinstrumentation';
+import {
+  getStructuredStackTrace,
+  GlobalErrorsInstrumentation,
+} from '../src/global-errors-autoinstrumentation';
 import timers from 'node:timers/promises';
 
 describe('Global Errors Instrumentation Tests', () => {
@@ -81,7 +84,7 @@ describe('Global Errors Instrumentation Tests', () => {
 
   describe('_computeStackTrace', () => {
     it('should return an empty object if error is undefined', () => {
-      expect(instr._computeStackTrace(undefined)).toEqual({});
+      expect(getStructuredStackTrace(undefined)).toEqual({});
     });
 
     it('should return an object with structured stack trace information', () => {
@@ -97,7 +100,7 @@ describe('Global Errors Instrumentation Tests', () => {
         '    at http://example.com/js/test.js:67:5\n' + // stack frame 5
         '    at namedFunc4 (http://example.com/js/script.js:100001:10002)'; // stack frame 6
 
-      const structuredStack = instr._computeStackTrace(err);
+      const structuredStack = getStructuredStackTrace(err);
 
       expect(structuredStack).toEqual({
         'exception.structured_stacktrace.columns': [


### PR DESCRIPTION
## Which problem is this PR solving?
Currently, error auto-instrumentation works well for uncaught errors but it is also useful to have a helper function that sends an exception span that can be called whenever needed for handled exceptions.

## Short description of the changes
- Added a `recordException` helper function that takes an error and creates an exception span for that error.
- Update deprecated semantic attribute constants
- Consolidate logic to format stack traces 

## How to verify that this has the expected result
- Tests pass 