### PR TITLE
fix: Add guard for null stack from tracekit.

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/global-errors-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/global-errors-autoinstrumentation.ts
@@ -30,7 +30,7 @@ export function getStructuredStackTrace(error: Error | undefined) {
   const functions: string[] = [];
   const urls: string[] = [];
 
-  if (!structuredStack) {
+  if (!Array.isArray(structuredStack)) {
     return {};
   }
 

--- a/packages/honeycomb-opentelemetry-web/src/global-errors-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/global-errors-autoinstrumentation.ts
@@ -30,12 +30,16 @@ export function getStructuredStackTrace(error: Error | undefined) {
   const functions: string[] = [];
   const urls: string[] = [];
 
-  for (const stackFrame of structuredStack) {
+  if (!structuredStack) {
+    return {};
+  }
+
+  structuredStack.forEach((stackFrame) => {
     lines.push(stackFrame.line);
     columns.push(stackFrame.column);
     functions.push(stackFrame.func);
     urls.push(stackFrame.url);
-  }
+  });
 
   return {
     'exception.structured_stacktrace.columns': columns,


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes https://github.com/honeycombio/honeycomb-opentelemetry-web/issues/430

## Short description of the changes
Adds a guard for `stack === null` from `tracekit`. Also added unit test.

