### PR TITLE
fix: Fallback to default trace endpoint for link exporter.

### DIFF
--- a/packages/honeycomb-opentelemetry-web/examples/hello-world-web/index.js
+++ b/packages/honeycomb-opentelemetry-web/examples/hello-world-web/index.js
@@ -30,6 +30,7 @@ const main = () => {
         dataAttributes: ['hello', 'barBiz'],
       },
     },
+    localVisualizations: true,
   });
   sdk.start();
   const tracer = trace.getTracer('click-tracer');

--- a/packages/honeycomb-opentelemetry-web/src/console-trace-link-exporter.ts
+++ b/packages/honeycomb-opentelemetry-web/src/console-trace-link-exporter.ts
@@ -4,6 +4,7 @@ import { HoneycombOptions } from './types';
 import {
   createHoneycombSDKLogMessage,
   getTracesApiKey,
+  getTracesEndpoint,
   isClassic,
 } from './util';
 import {
@@ -24,7 +25,9 @@ export function configureConsoleTraceLinkExporter(
   options?: HoneycombOptions,
 ): SpanExporter {
   const apiKey = getTracesApiKey(options);
-  const { authRoot, uiRoot } = getUrlRoots(options?.endpoint);
+  const { authRoot, uiRoot } = getUrlRoots(
+    options?.tracesEndpoint || getTracesEndpoint(options),
+  );
   return new ConsoleTraceLinkExporter(
     options?.serviceName,
     apiKey,

--- a/packages/honeycomb-opentelemetry-web/test/honeycomb-debug.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/honeycomb-debug.test.ts
@@ -69,5 +69,34 @@ describe('when debug is set to true', () => {
         `@honeycombio/opentelemetry-web: Sample Rate configured for traces: '${testConfig.sampleRate}'`,
       );
     });
+    it('should log the configured options to the console when endpoint is omitted', () => {
+      const testConfig = {
+        debug: true,
+        apiKey: 'my-key',
+        serviceName: 'my-service',
+        sampleRate: 2,
+      };
+      new HoneycombWebSDK(testConfig);
+      expect(consoleSpy).toHaveBeenNthCalledWith(
+        3,
+        '@honeycombio/opentelemetry-web: 🐝 Honeycomb Web SDK Debug Mode Enabled 🐝',
+      );
+      expect(consoleSpy).toHaveBeenNthCalledWith(
+        4,
+        `@honeycombio/opentelemetry-web: API Key configured for traces: '${testConfig.apiKey}'`,
+      );
+      expect(consoleSpy).toHaveBeenNthCalledWith(
+        5,
+        `@honeycombio/opentelemetry-web: Service Name configured for traces: '${testConfig.serviceName}'`,
+      );
+      expect(consoleSpy).toHaveBeenNthCalledWith(
+        6,
+        `@honeycombio/opentelemetry-web: Endpoint configured for traces: 'https://api.honeycomb.io/v1/traces'`,
+      );
+      expect(consoleSpy).toHaveBeenNthCalledWith(
+        7,
+        `@honeycombio/opentelemetry-web: Sample Rate configured for traces: '${testConfig.sampleRate}'`,
+      );
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #443 

## Short description of the changes

Fall back to computed traces endpoint if not supplied.

## How to verify that this has the expected result
Configure the sample app (without) providing an end point and run:
```shell
npm run example:start:hello-world-web
```
You should see the SDK start successfully and links to traces in the console.


