### PR TITLE
maint: Use LTS tag

### DIFF
--- a/.circleci/build.yml
+++ b/.circleci/build.yml
@@ -27,7 +27,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: cimg/node:18.19
+      - image: cimg/node:lts
   github:
     docker:
       - image: cibuilds/github:0.13.0
@@ -192,5 +192,3 @@ workflows:
           requires:
             - build
             - smoke_test
-
- 


### PR DESCRIPTION
We are using a pretty old node version for out CI. What do people think about using the lts tag for this? 