### PR TITLE
rel: Releasing honeycomb-opentelemetry-web-v0.15.0

### DIFF
--- a/packages/honeycomb-opentelemetry-web/CHANGELOG.md
+++ b/packages/honeycomb-opentelemetry-web/CHANGELOG.md
@@ -1,5 +1,22 @@
 # honeycomb-opentelemetry-web changelog
 
+## v0.15.0 [beta] - 2025-03-24
+
+### ✨ Features
+
+- feat: Allow custom session id provider (#489) | @martin308
+
+### 🛠️ Maintenance
+
+- maint(deps-dev): bump the dev-dependencies group in /packages/honeycomb-opentelemetry-web with 2 updates (#496) | @dependabot
+- maint: Peer dependencies and testing for v2 network instrumentation (#493) | @pkanal
+- maint(deps-dev): bump esbuild from 0.23.0 to 0.25.1 in /packages/honeycomb-opentelemetry-web (#495) | @dependabot
+- maint(deps-dev): bump the dev-dependencies group in /packages/honeycomb-opentelemetry-web with 2 updates (#491) | @dependabot
+- maint(deps): bump the example-deps group across 6 directories with 13 updates (#492) | @dependabot
+- maint: Consolidate all the dependabot for examples (#486) | @martin308
+- maint: npm update all examples (#488) | @martin308
+- maint: Use LTS tag (#487) | @martin308
+
 ## v0.14.0 [beta] - 2025-03-19
 
 ### ✨ Features

--- a/packages/honeycomb-opentelemetry-web/README.md
+++ b/packages/honeycomb-opentelemetry-web/README.md
@@ -13,7 +13,7 @@ Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) in the browser. 
 Latest release:
 
 * built with OpenTelemetry JS [Stable v1.30.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.30.0)[Experimental v0.57.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.57.0), [API v1.9.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/api%2Fv1.9.0)
-* compatible with OpenTelemetry Auto-Instrumentations for Web [~0.45.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-web-v0.45.0)
+* compatible with OpenTelemetry Auto-Instrumentations for Web [~0.46.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-web-v0.46.0)
 
 This package sets up OpenTelemetry for tracing, using our recommended practices, including:
 

--- a/packages/honeycomb-opentelemetry-web/package-lock.json
+++ b/packages/honeycomb-opentelemetry-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@honeycombio/opentelemetry-web",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@honeycombio/opentelemetry-web",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.24.7",

--- a/packages/honeycomb-opentelemetry-web/package.json
+++ b/packages/honeycomb-opentelemetry-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honeycombio/opentelemetry-web",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Honeycomb OpenTelemetry Wrapper for Browser Applications",
   "main": "./dist/cjs/index.js",
   "exports": {

--- a/packages/honeycomb-opentelemetry-web/src/version.ts
+++ b/packages/honeycomb-opentelemetry-web/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.14.0';
+export const VERSION = '0.15.0';


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Releasing honeycomb-opentelemetry-web-v0.15.0
 
## Short description of the changes
## v0.15.0 [beta] - 2025-03-24

### ✨ Features

- feat: Allow custom session id provider (#489) | @martin308

### 🛠️ Maintenance

- maint(deps-dev): bump the dev-dependencies group in /packages/honeycomb-opentelemetry-web with 2 updates (#496) | @dependabot
- maint: Peer dependencies and testing for v2 network instrumentation (#493) | @pkanal
- maint(deps-dev): bump esbuild from 0.23.0 to 0.25.1 in /packages/honeycomb-opentelemetry-web (#495) | @dependabot
- maint(deps-dev): bump the dev-dependencies group in /packages/honeycomb-opentelemetry-web with 2 updates (#491) | @dependabot
- maint(deps): bump the example-deps group across 6 directories with 13 updates (#492) | @dependabot
- maint: Consolidate all the dependabot for examples (#486) | @martin308
- maint: npm update all examples (#488) | @martin308
- maint: Use LTS tag (#487) | @martin308
