### PR TITLE
Add top-level types element to package.json

### DIFF
--- a/packages/honeycomb-opentelemetry-web/package.json
+++ b/packages/honeycomb-opentelemetry-web/package.json
@@ -3,6 +3,7 @@
   "version": "0.15.0",
   "description": "Honeycomb OpenTelemetry Wrapper for Browser Applications",
   "main": "./dist/cjs/index.js",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -13,6 +14,7 @@
     },
     "./experimental": {
       "types": "./dist/types/experimental/index.d.ts",
+      "node": "./dist/cjs/experimental/index.js",
       "require": "./dist/cjs/experimental/index.js",
       "import": "./dist/esm/experimental/index.js",
       "default": "./dist/esm/experimental/index.js"


### PR DESCRIPTION
## Which problem is this PR solving?

Errors reporting unable to find types for this package. Here is the error I get when running under `jest`

``` 
src/javascript/tracing/honeycomb.ts:4:8 - error TS7016: Could not find a declaration file for module '@honeycombio/opentelemetry-web'. 'node_modules/@honeycombio/opentelemetry-web/dist/cjs/index.js' implicitly has an 'any' type.
      Try `npm i --save-dev @types/honeycombio__opentelemetry-web` if it exists or add a new declaration (.d.ts) file containing `declare module '@honeycombio/opentelemetry-web';`

    4 } from '@honeycombio/opentelemetry-web'
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR resolves the error.


## Short description of the changes

## How to verify that this has the expected result


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209957762639823