### PR TITLE
feat: add an option to disable automatic browser attributes

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/configure-resource-attributes.ts
+++ b/packages/honeycomb-opentelemetry-web/src/configure-resource-attributes.ts
@@ -15,9 +15,13 @@ export const configureResourceAttributes = (
   options?: HoneycombOptions,
 ): Resource => {
   let resource = resourceFromAttributes({})
-    .merge(configureEntryPageResource(options?.entryPageAttributes))
-    .merge(configureBrowserAttributesResource())
-    .merge(configureHoneycombResource());
+    .merge(configureEntryPageResource(options?.entryPageAttributes));
+
+  if (!options?.disableBrowserAttributes) {
+    resource = resource.merge(configureBrowserAttributesResource())
+  }
+
+  resource = resource.merge(configureHoneycombResource());
 
   if (options?.resource) {
     resource = resource.merge(options.resource);

--- a/packages/honeycomb-opentelemetry-web/src/configure-resource-attributes.ts
+++ b/packages/honeycomb-opentelemetry-web/src/configure-resource-attributes.ts
@@ -14,11 +14,12 @@ import { configureBrowserAttributesResource } from './browser-attributes-resourc
 export const configureResourceAttributes = (
   options?: HoneycombOptions,
 ): Resource => {
-  let resource = resourceFromAttributes({})
-    .merge(configureEntryPageResource(options?.entryPageAttributes));
+  let resource = resourceFromAttributes({}).merge(
+    configureEntryPageResource(options?.entryPageAttributes),
+  );
 
   if (!options?.disableBrowserAttributes) {
-    resource = resource.merge(configureBrowserAttributesResource())
+    resource = resource.merge(configureBrowserAttributesResource());
   }
 
   resource = resource.merge(configureHoneycombResource());

--- a/packages/honeycomb-opentelemetry-web/src/configure-resource-attributes.ts
+++ b/packages/honeycomb-opentelemetry-web/src/configure-resource-attributes.ts
@@ -14,12 +14,12 @@ import { configureBrowserAttributesResource } from './browser-attributes-resourc
 export const configureResourceAttributes = (
   options?: HoneycombOptions,
 ): Resource => {
-  let resource = resourceFromAttributes({}).merge(
-    configureEntryPageResource(options?.entryPageAttributes),
-  );
+  let resource = resourceFromAttributes({});
 
   if (!options?.disableBrowserAttributes) {
-    resource = resource.merge(configureBrowserAttributesResource());
+    resource = resource
+      .merge(configureEntryPageResource(options?.entryPageAttributes))
+      .merge(configureBrowserAttributesResource());
   }
 
   resource = resource.merge(configureHoneycombResource());

--- a/packages/honeycomb-opentelemetry-web/src/configure-span-processors.ts
+++ b/packages/honeycomb-opentelemetry-web/src/configure-span-processors.ts
@@ -15,12 +15,19 @@ import { defaultSessionProvider } from './default-session-provider';
 export const configureSpanProcessors = (
   options?: HoneycombOptions,
 ): SpanProcessor[] => {
-  return [
-    new BrowserAttributesSpanProcessor(),
+  const processors: SpanProcessor[] = [];
+
+  if (!options?.disableBrowserAttributes) {
+    processors.push(new BrowserAttributesSpanProcessor());
+  }
+
+  processors.push(
     new BaggageSpanProcessor(),
     createSessionSpanProcessor(
       options?.sessionProvider || defaultSessionProvider,
     ),
     ...(options?.spanProcessors || []),
-  ];
+  );
+
+  return processors;
 };

--- a/packages/honeycomb-opentelemetry-web/src/types.ts
+++ b/packages/honeycomb-opentelemetry-web/src/types.ts
@@ -118,6 +118,9 @@ export interface HoneycombOptions extends Partial<WebSDKConfiguration> {
   /** Additional attributes, will be included as fields on all data */
   resourceAttributes?: DetectedResourceAttributes;
 
+  /** Prevents attaching automatically-derived browser-derived attributes to signals. */
+  disableBrowserAttributes?: boolean;
+
   /** The local visualizations flag enables logging Honeycomb URLs for completed traces. Do not use in production.
    * Defaults to 'false'.
    */

--- a/packages/honeycomb-opentelemetry-web/test/honeycomb-otel-sdk.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/honeycomb-otel-sdk.test.ts
@@ -244,6 +244,7 @@ describe('disabling browser attributes', () => {
 
     const attributes = honeycomb.getResourceAttributes();
     expect(attributes['browser.name']).toBeUndefined();
+    expect(attributes['entry_page.path']).toBeUndefined();
   });
 
   test('does not include browser span processor when `config.disableBrowserAttributes` is false', async () => {

--- a/packages/honeycomb-opentelemetry-web/test/honeycomb-otel-sdk.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/honeycomb-otel-sdk.test.ts
@@ -271,8 +271,8 @@ describe('disabling browser attributes', () => {
 
     const finishedSpans = exporter.getFinishedSpans();
     expect(finishedSpans).toHaveLength(1);
-    expect(finishedSpans[0].attributes["browser.width"]).toBeUndefined();
-    expect(finishedSpans[0].attributes["browser.height"]).toBeUndefined();
+    expect(finishedSpans[0].attributes['browser.width']).toBeUndefined();
+    expect(finishedSpans[0].attributes['browser.height']).toBeUndefined();
 
     await honeycomb.shutdown();
     trace.disable();


### PR DESCRIPTION
## Which problem is this PR solving?

It is currently not possible to disable automatic attributes inferred by the browser, which is inconsistent with the options to turn off other auto-instrumentation. It also prevents this SDK from being used in non-browser web contexts.

## Short description of the changes

Adds a new `disableBrowserAttributes` config option, which defaults to false. Turning on this option prevents the Honeycomb SDK from automatically adding browser-derived resource attributes, as well as the browser attribute span processor.

## How to verify that this has the expected result

- New unit tests added.
- Smoke tests still pass.