### PR TITLE
fix: explicitly add default resource attributes

### DIFF
--- a/packages/honeycomb-opentelemetry-web/smoke-tests/smoke-e2e.bats
+++ b/packages/honeycomb-opentelemetry-web/smoke-tests/smoke-e2e.bats
@@ -25,6 +25,19 @@ teardown_file() {
   assert_equal "$result" '"hny-web-distro-example:custom-with-collector-ts"'
 }
 
+@test "SDK telemetry includes default resource attributes" {
+  name=$(resource_attributes_received | jq "select(.key == \"telemetry.sdk.name\").value.stringValue")
+  assert_equal "$name" '"opentelemetry"'
+
+  language=$(resource_attributes_received | jq "select(.key == \"telemetry.sdk.language\").value.stringValue")
+  assert_equal "$language" '"webjs"'
+
+  # We want to check that the version attribute exists but not specifically what it is to avoid smoke tests breaking everytime we upgrade OTel packages
+  version=$(resource_attributes_received | jq "select(.key == \"telemetry.sdk.version\").value.stringValue")
+  assert_not_empty "$version"
+}
+
+
 @test "SDK telemetry includes Honeycomb distro version" {
   version=$(resource_attributes_received | jq "select(.key == \"honeycomb.distro.version\").value.stringValue")
   assert_not_empty "$version"

--- a/packages/honeycomb-opentelemetry-web/src/base-otel-sdk.ts
+++ b/packages/honeycomb-opentelemetry-web/src/base-otel-sdk.ts
@@ -22,9 +22,10 @@ import {
   Instrumentation,
   registerInstrumentations,
 } from '@opentelemetry/instrumentation';
+import type { Resource } from '@opentelemetry/resources';
 import {
+  defaultResource,
   detectResources,
-  Resource,
   ResourceDetectionConfig,
   ResourceDetector,
   resourceFromAttributes,
@@ -67,7 +68,11 @@ export class WebSDK {
    * Create a new Web SDK instance
    */
   public constructor(configuration: Partial<WebSDKConfiguration> = {}) {
-    this._resource = configuration.resource ?? resourceFromAttributes({});
+    // As of v2 of the JS packages, we need to explicitly start with the default resource that contains
+    // telemetry.sdk.language etc.
+    this._resource = defaultResource().merge(
+      configuration.resource ?? resourceFromAttributes({}),
+    );
     this._resourceDetectors = configuration.resourceDetectors ?? [
       browserDetector,
     ];

--- a/packages/honeycomb-opentelemetry-web/test/honeycomb-otel-sdk.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/honeycomb-otel-sdk.test.ts
@@ -19,6 +19,11 @@ import {
   SimpleSpanProcessor,
   SpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
+import {
+  ATTR_TELEMETRY_SDK_LANGUAGE,
+  ATTR_TELEMETRY_SDK_NAME,
+  ATTR_TELEMETRY_SDK_VERSION,
+} from '@opentelemetry/semantic-conventions';
 
 test('it should extend the OTel WebSDK', () => {
   const honeycomb = new HoneycombWebSDK();
@@ -60,6 +65,17 @@ describe('resource config', () => {
     expect(attributes.myTestAttr).toEqual('my-test-attr');
     expect(attributes.jumpingJacks).toEqual(25);
     expect(attributes.marbles).toEqual(52);
+  });
+
+  test('it should include attributes from the default resource', () => {
+    const honeycomb = new HoneycombWebSDK({});
+
+    const resourceAttributes = honeycomb.getResourceAttributes();
+    expect(resourceAttributes[ATTR_TELEMETRY_SDK_LANGUAGE]).toBeDefined();
+    expect(resourceAttributes[ATTR_TELEMETRY_SDK_NAME]).toEqual(
+      'opentelemetry',
+    );
+    expect(resourceAttributes[ATTR_TELEMETRY_SDK_VERSION]).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Which problem is this PR solving?
As of v0.15.0 (the version where we upgraded to v2 of OTel packages), the following attributes disappeared from telemetry:
- `telemetry.sdk.name`
- `telemetry.sdk.language`
- `telemetry.sdk.version`

It seems like in v2, these have to be [explicitly merged with other resources](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts#L49) when using the `WebTracerProvider` because the default behaviour is to overwrite them with resources that have already been passed in.

## Short description of the changes
- Add `defaultResource` to base SDK
- Add unit tests to make sure these attributes are present
- Add smoke tests to make sure these attributes are present

## How to verify that this has the expected result
- Check example apps resource attributes
- Unit tests pass
- Smoke tests pass