### PR TITLE
fix: Add repository to package.json

### DIFF
--- a/packages/honeycomb-opentelemetry-web/package.json
+++ b/packages/honeycomb-opentelemetry-web/package.json
@@ -2,6 +2,11 @@
   "name": "@honeycombio/opentelemetry-web",
   "version": "0.17.0",
   "description": "Honeycomb OpenTelemetry Wrapper for Browser Applications",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/honeycombio/honeycomb-opentelemetry-web.git",
+    "directory": "packages/honeycomb-opentelemetry-web"
+  },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #514 

I'm hoping that his will help with the dependabot issue linked above 🤞🏽 . There is no explicit guidance for maintainers of packages on what specifically dependabot is looking for and [their advice for now is to read the source code](https://github.com/dependabot/dependabot-core/issues/4656#issuecomment-1021739194).

## Short description of the changes
Add repository field to package.json. It looks like [dependabot looks for the repo field](https://github.com/dependabot/dependabot-core/blob/main/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb#L95) to get metadata for PRs.

## How to verify that this has the expected result
Check dependabot PRs in other repos that are installing this package.
