### PR TITLE
fix: upgrade orb version to test bugfix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@1.1.0
+  path-filtering: circleci/path-filtering@1.3.0
 
 parameters:
   base-path:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
The filter branch orb was outdated and causing all builds to fail. 


- Closes #<enter issue here>

## Short description of the changes
This upgrades the minor version to `1.3.0` which fixes the issue.

## How to verify that this has the expected result
Builds will no longer fail at the filter branch task
