### PR TITLE
rel: Releasing honeycomb-opentelemetry-web-v0.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "honeycomb-opentelemetry-web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "honeycomb-opentelemetry-web",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/packages/honeycomb-opentelemetry-web/CHANGELOG.md
+++ b/packages/honeycomb-opentelemetry-web/CHANGELOG.md
@@ -1,5 +1,29 @@
 # honeycomb-opentelemetry-web changelog
 
+## v0.18.0 [beta] - 2025-05-20
+
+### ✨ Features
+- feat: telemetry distro attrs (#530) | @martin308
+
+### 🐛 Fixes
+- fix: upgrade orb version to test bugfix (#524) | @arriIsHere
+
+### 🛠️ Maintenance
+- maint(deps): bump the otel group in /packages/honeycomb-opentelemetry-web with 9 updates (#535) | @dependabot
+- maint(deps-dev): bump the dev-dependencies group in /packages/honeycomb-opentelemetry-web with 3 updates (#536) | @dependabot
+- chore: Upgrade to web-vitals 5.0.0 (#534) | @wolfgangcodes
+- maint(deps): bump @opentelemetry/semantic-conventions from 1.32.0 to 1.33.0 in /packages/honeycomb-opentelemetry-web in the otel group (#532) | @dependabot
+- maint(deps-dev): bump the dev-dependencies group in /packages/honeycomb-opentelemetry-web with 3 updates (#533) | @dependabot
+- maint(deps): bump @babel/runtime from 7.27.0 to 7.27.1 in /packages/honeycomb-opentelemetry-web (#529) | @dependabot
+- maint(deps-dev): bump the dev-dependencies group in /packages/honeycomb-opentelemetry-web with 3 updates (#528) | @dependabot
+- maint(deps-dev): bump http-proxy-middleware from 2.0.7 to 2.0.9 in /packages/honeycomb-opentelemetry-web/examples/custom-with-collector-ts (#527) | @dependabot
+- maint(deps): bump the example-deps group across 6 directories with 9 updates (#525) | @dependabot
+- maint: remove .github/workflows/gh-issue-to-asana.yml (#526) | @martin308
+- maint(deps-dev): bump rollup from 4.40.0 to 4.40.1 in /packages/honeycomb-opentelemetry-web in the dev-dependencies group (#521) | @dependabot
+- maint(deps): bump http-proxy-middleware from 2.0.7 to 2.0.9 in /packages/honeycomb-opentelemetry-web/examples/hello-world-react-create-app (#522) | @dependabot
+- maint(deps): bump react-router and react-router-dom in /packages/honeycomb-opentelemetry-web/examples/experimental/user-interaction-instrumentation (#523) | @dependabot
+- maint(deps): bump react-router and react-router-dom in /packages/honeycomb-opentelemetry-web/examples/hello-world-react-create-app (#520) | @dependabot
+
 ## v0.17.1 [beta] - 2025-04-24
 
 ### 🐛 Fixes

--- a/packages/honeycomb-opentelemetry-web/CHANGELOG.md
+++ b/packages/honeycomb-opentelemetry-web/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.18.0 [beta] - 2025-05-20
 
+### 💥 Breaking Changes
+- Upgrade to web-vitals 5.0.0 (chore: Upgrade to web-vitals 5.0.0 #534) removes support for FID since it has been removed from the web-vitals@5.0.0 for the full set of upstream changes see changelog here
+
 ### ✨ Features
 - feat: telemetry distro attrs (#530) | @martin308
 

--- a/packages/honeycomb-opentelemetry-web/CHANGELOG.md
+++ b/packages/honeycomb-opentelemetry-web/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.18.0 [beta] - 2025-05-20
 
 ### 💥 Breaking Changes
-- Upgrade to web-vitals 5.0.0 (chore: Upgrade to web-vitals 5.0.0 #534) removes support for FID since it has been removed from the web-vitals@5.0.0 for the full set of upstream changes see changelog here
+- **chore: Upgrade to web-vitals 5.0.0 (#534)** removes support for FID since it has been removed from `web-vitals@5.0.0`. For the full set of upstream changes see changelog [here](https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v500-2025-05-07)
 
 ### ✨ Features
 - feat: telemetry distro attrs (#530) | @martin308

--- a/packages/honeycomb-opentelemetry-web/README.md
+++ b/packages/honeycomb-opentelemetry-web/README.md
@@ -12,7 +12,7 @@ Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) in the browser. 
 
 Latest release:
 
-* built with OpenTelemetry JS [Stable v2.0.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0), [Experimental v0.201.1](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.201.1), [API v1.9.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/api%2Fv1.9.0), [Semantic Conventions v1.32.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/semconv%2Fv1.32.0)
+* built with OpenTelemetry JS [Stable v2.0.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0), [Experimental v0.201.1](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.201.1), [API v1.9.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/api%2Fv1.9.0), [Semantic Conventions v1.33.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/semconv%2Fv1.33.0)
 * compatible with OpenTelemetry Auto-Instrumentations for Web [~0.47.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-web-v0.47.0)
 
 This package sets up OpenTelemetry for tracing, using our recommended practices, including:

--- a/packages/honeycomb-opentelemetry-web/README.md
+++ b/packages/honeycomb-opentelemetry-web/README.md
@@ -12,8 +12,8 @@ Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) in the browser. 
 
 Latest release:
 
-* built with OpenTelemetry JS [Stable v2.0.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.30.0)[Experimental v0.200.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.57.0), [API v1.9.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/api%2Fv1.9.0), [Semantic Conventions v1.32.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/semconv%2Fv1.32.0)
-* compatible with OpenTelemetry Auto-Instrumentations for Web [~0.46.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-web-v0.46.0)
+* built with OpenTelemetry JS [Stable v2.0.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0), [Experimental v0.201.1](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.201.1), [API v1.9.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/api%2Fv1.9.0), [Semantic Conventions v1.32.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/semconv%2Fv1.32.0)
+* compatible with OpenTelemetry Auto-Instrumentations for Web [~0.47.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-web-v0.47.0)
 
 This package sets up OpenTelemetry for tracing, using our recommended practices, including:
 

--- a/packages/honeycomb-opentelemetry-web/package-lock.json
+++ b/packages/honeycomb-opentelemetry-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@honeycombio/opentelemetry-web",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@honeycombio/opentelemetry-web",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.24.7",

--- a/packages/honeycomb-opentelemetry-web/package.json
+++ b/packages/honeycomb-opentelemetry-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honeycombio/opentelemetry-web",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Honeycomb OpenTelemetry Wrapper for Browser Applications",
   "repository": {
     "type": "git",

--- a/packages/honeycomb-opentelemetry-web/src/version.ts
+++ b/packages/honeycomb-opentelemetry-web/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.17.1';
+export const VERSION = '0.18.0';


### PR DESCRIPTION
Releasing new minor version of `honeycomb-opentelemetry-web` package.
