### PR TITLE
fix: honoring custom sampler when provided by user.

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/deterministic-sampler.ts
+++ b/packages/honeycomb-opentelemetry-web/src/deterministic-sampler.ts
@@ -16,7 +16,7 @@ import { HoneycombOptions } from './types';
  * @returns a {@link DeterministicSampler}
  */
 export const configureSampler = (options?: HoneycombOptions) => {
-  if(options?.sampler) {
+  if (options?.sampler) {
     return options.sampler;
   }
   const sampleRate = getSampleRate(options);

--- a/packages/honeycomb-opentelemetry-web/src/deterministic-sampler.ts
+++ b/packages/honeycomb-opentelemetry-web/src/deterministic-sampler.ts
@@ -15,7 +15,7 @@ import { HoneycombOptions } from './types';
  * @param options The {@link HoneycombOptions}
  * @returns a {@link DeterministicSampler}
  */
-export const configureDeterministicSampler = (options?: HoneycombOptions) => {
+export const configureSampler = (options?: HoneycombOptions) => {
   if(options.sampler) {
     return options.sampler;
   }

--- a/packages/honeycomb-opentelemetry-web/src/deterministic-sampler.ts
+++ b/packages/honeycomb-opentelemetry-web/src/deterministic-sampler.ts
@@ -16,7 +16,7 @@ import { HoneycombOptions } from './types';
  * @returns a {@link DeterministicSampler}
  */
 export const configureSampler = (options?: HoneycombOptions) => {
-  if(options.sampler) {
+  if(options?.sampler) {
     return options.sampler;
   }
   const sampleRate = getSampleRate(options);

--- a/packages/honeycomb-opentelemetry-web/src/deterministic-sampler.ts
+++ b/packages/honeycomb-opentelemetry-web/src/deterministic-sampler.ts
@@ -11,11 +11,14 @@ import { HoneycombOptions } from './types';
 
 /**
  * Builds and returns a Deterministic Sampler that uses the provided sample rate to
- * configure the inner sampler.
+ * configure the inner sampler, if custom sampler has not provided.
  * @param options The {@link HoneycombOptions}
  * @returns a {@link DeterministicSampler}
  */
 export const configureDeterministicSampler = (options?: HoneycombOptions) => {
+  if(options.sampler) {
+    return options.sampler;
+  }
   const sampleRate = getSampleRate(options);
   return new DeterministicSampler(sampleRate);
 };

--- a/packages/honeycomb-opentelemetry-web/src/honeycomb-otel-sdk.ts
+++ b/packages/honeycomb-opentelemetry-web/src/honeycomb-otel-sdk.ts
@@ -1,7 +1,7 @@
 import { WebSDK } from './base-otel-sdk';
 import { HoneycombOptions } from './types';
 import { configureDebug } from './honeycomb-debug';
-import { configureDeterministicSampler } from './deterministic-sampler';
+import { configureSampler } from './deterministic-sampler';
 import { validateOptionsWarnings } from './validate-options';
 import { WebVitalsInstrumentation } from './web-vitals-autoinstrumentation';
 import { GlobalErrorsInstrumentation } from './global-errors-autoinstrumentation';
@@ -35,7 +35,7 @@ export class HoneycombWebSDK extends WebSDK {
       ...options,
       instrumentations,
       resource: configureResourceAttributes(options),
-      sampler: configureDeterministicSampler(options),
+      sampler: configureSampler(options),
       spanProcessors: configureSpanProcessors(options),
       traceExporter: configureTraceExporters(options),
       metricExporters: configureMetricExporters(options),

--- a/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
@@ -65,7 +65,7 @@ describe('configureSampler', () => {
     const sampler = configureSampler(options);
     expect(sampler).toBeInstanceOf(CustomSampler);
   });
-  
+
   test('sample rate of 1 configures inner AlwaysOnSampler', () => {
     const options = {
       sampleRate: 1,

--- a/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
@@ -27,12 +27,6 @@ const getSamplingResult = (sampler: DeterministicSampler): SamplingResult => {
   );
 };
 
-class CustomSampler {
-  toString() {
-    return 'CustomSampler';
-  }
-}
-
 describe('deterministic sampler', () => {
   test('sampler with rate of 1 configures inner AlwaysOnSampler', () => {
     const sampler = new DeterministicSampler(1);
@@ -60,10 +54,13 @@ describe('deterministic sampler', () => {
 describe('configureSampler', () => {
   test('when custom sampler is provided, it is returned', () => {
     const options = {
-      sampler: new CustomSampler(),
+      sampler: new DeterministicSampler(1),
     };
     const sampler = configureSampler(options);
-    expect(sampler).toBeInstanceOf(CustomSampler);
+    expect(sampler).toBeInstanceOf(DeterministicSampler);
+    consst result = getSamplingResult(sampler);
+    expect(result.decision).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+    expect(result.attributes).toEqual({ SampleRate: 1 });
   });
 
   test('sample rate of 1 configures inner AlwaysOnSampler', () => {

--- a/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
@@ -4,6 +4,7 @@ import {
 } from '../src/deterministic-sampler';
 import { ROOT_CONTEXT, SpanKind, trace, TraceFlags } from '@opentelemetry/api';
 import {
+  AlwaysOnSampler,
   SamplingDecision,
   SamplingResult,
 } from '@opentelemetry/sdk-trace-base';
@@ -52,15 +53,12 @@ describe('deterministic sampler', () => {
 });
 
 describe('configureSampler', () => {
-  test('when custom sampler is provided, it is returned', () => {
+  test('when a sampler is provided, it is returned', () => {
     const options = {
-      sampler: new DeterministicSampler(1),
+      sampler: new AlwaysOnSampler(),
     };
     const sampler = configureSampler(options);
-    expect(sampler).toBeInstanceOf(DeterministicSampler);
-    const result = getSamplingResult(sampler);
-    expect(result.decision).toBe(SamplingDecision.RECORD_AND_SAMPLED);
-    expect(result.attributes).toEqual({ SampleRate: 1 });
+    expect(sampler).toBeInstanceOf(AlwaysOnSampler);
   });
 
   test('sample rate of 1 configures inner AlwaysOnSampler', () => {

--- a/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
@@ -58,7 +58,7 @@ describe('configureSampler', () => {
     };
     const sampler = configureSampler(options);
     expect(sampler).toBeInstanceOf(DeterministicSampler);
-    consst result = getSamplingResult(sampler);
+    const result = getSamplingResult(sampler);
     expect(result.decision).toBe(SamplingDecision.RECORD_AND_SAMPLED);
     expect(result.attributes).toEqual({ SampleRate: 1 });
   });

--- a/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
@@ -28,9 +28,6 @@ const getSamplingResult = (sampler: DeterministicSampler): SamplingResult => {
 };
 
 class CustomSampler {
-  shouldSample(context, traceId, spanName, spanKind, attributes, links) {
-    return SamplingDecision.NOT_RECORD;
-  }
   toString() {
     return 'CustomSampler';
   }

--- a/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
@@ -1,5 +1,5 @@
 import {
-  configureDeterministicSampler,
+  configureSampler,
   DeterministicSampler,
 } from '../src/deterministic-sampler';
 import { ROOT_CONTEXT, SpanKind, trace, TraceFlags } from '@opentelemetry/api';
@@ -27,6 +27,15 @@ const getSamplingResult = (sampler: DeterministicSampler): SamplingResult => {
   );
 };
 
+class CustomSampler {
+  shouldSample(context, traceId, spanName, spanKind, attributes, links) {
+    return SamplingDecision.NOT_RECORD;
+  }
+  toString() {
+    return 'CustomSampler';
+  }
+}
+
 describe('deterministic sampler', () => {
   test('sampler with rate of 1 configures inner AlwaysOnSampler', () => {
     const sampler = new DeterministicSampler(1);
@@ -51,12 +60,20 @@ describe('deterministic sampler', () => {
   });
 });
 
-describe('configureDeterministicSampler', () => {
+describe('configureSampler', () => {
+  test('when custom sampler is provided, it is returned', () => {
+    const options = {
+      sampler: new CustomSampler(),
+    };
+    const sampler = configureSampler(options);
+    expect(sampler).toBeInstanceOf(CustomSampler);
+  });
+  
   test('sample rate of 1 configures inner AlwaysOnSampler', () => {
     const options = {
       sampleRate: 1,
     };
-    const sampler = configureDeterministicSampler(options);
+    const sampler = configureSampler(options);
     expect(sampler).toBeInstanceOf(DeterministicSampler);
     expect(sampler.toString()).toBe('DeterministicSampler(AlwaysOnSampler)');
 
@@ -69,7 +86,7 @@ describe('configureDeterministicSampler', () => {
     const options = {
       sampleRate: 0,
     };
-    const sampler = configureDeterministicSampler(options);
+    const sampler = configureSampler(options);
     expect(sampler).toBeInstanceOf(DeterministicSampler);
     expect(sampler.toString()).toBe('DeterministicSampler(AlwaysOffSampler)');
 
@@ -82,7 +99,7 @@ describe('configureDeterministicSampler', () => {
     const options = {
       sampleRate: -42,
     };
-    const sampler = configureDeterministicSampler(options);
+    const sampler = configureSampler(options);
     expect(sampler).toBeInstanceOf(DeterministicSampler);
     expect(sampler.toString()).toBe('DeterministicSampler(AlwaysOnSampler)');
 
@@ -95,7 +112,7 @@ describe('configureDeterministicSampler', () => {
     const options = {
       sampleRate: 10,
     };
-    const sampler = configureDeterministicSampler(options);
+    const sampler = configureSampler(options);
     expect(sampler).toBeInstanceOf(DeterministicSampler);
     expect(sampler.toString()).toBe(
       'DeterministicSampler(TraceIdRatioBased{0.1})',

--- a/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/deterministic-sampler.test.ts
@@ -5,6 +5,7 @@ import {
 import { ROOT_CONTEXT, SpanKind, trace, TraceFlags } from '@opentelemetry/api';
 import {
   AlwaysOnSampler,
+  Sampler,
   SamplingDecision,
   SamplingResult,
 } from '@opentelemetry/sdk-trace-base';
@@ -13,7 +14,7 @@ const traceId = 'd4cda95b652f4a1592b449d5929fda1b';
 const spanId = '6e0c63257de34c92';
 const spanName = 'doStuff';
 
-const getSamplingResult = (sampler: DeterministicSampler): SamplingResult => {
+const getSamplingResult = (sampler: Sampler): SamplingResult => {
   return sampler.shouldSample(
     trace.setSpanContext(ROOT_CONTEXT, {
       traceId,


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #557 

## Short description of the changes
This change provides a small quick fix to:
- return custom sampler in case user provided it through the options when running HNY SDK
- renaming the function configureDeterministicSampler to configureSampler, since this does not only configure deterministic sampler (function name a bit misleading)
- adding unit test to test the functionality.

## How to verify that this has the expected result
provided custom sampler in option will be used when provided. Internal deterministic sampler is used when the custom sampler does not exist, and sample rate is provided.