### PR TITLE
maint: Remove deprecated dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
       interval: 'weekly' # Check for updates every week
     labels:
       - 'type: dependencies' # Add label
-    reviewers:
-      - 'honeycombio/frontend-observability'
     commit-message:
       prefix: 'maint' # Add PR title prefix
       include: 'scope'
@@ -41,8 +39,6 @@ updates:
       interval: 'monthly' # Check for updates every month
     labels:
       - 'type: dependencies' # Add label
-    reviewers:
-      - 'honeycombio/frontend-observability'
     commit-message:
       prefix: 'maint' # Add PR title prefix
       include: 'scope'


### PR DESCRIPTION
## Short description of the changes

The last dependabot PR contained the message that this field was being deprecated. We already use the code owners file so this should still work as is.