### PR TITLE
feat: Export attribute names as constants

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/browser-attributes-resource.ts
+++ b/packages/honeycomb-opentelemetry-web/src/browser-attributes-resource.ts
@@ -3,7 +3,22 @@ import {
   Resource,
   resourceFromAttributes,
 } from '@opentelemetry/resources';
+import { ATTR_USER_AGENT_ORIGINAL } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_BROWSER_LANGUAGE,
+  ATTR_BROWSER_MOBILE,
+} from '@opentelemetry/semantic-conventions/incubating';
 import UAParser from 'ua-parser-js';
+import {
+  ATTR_BROWSER_NAME,
+  ATTR_BROWSER_TOUCH_SCREEN_ENABLED,
+  ATTR_BROWSER_VERSION,
+  ATTR_DEVICE_TYPE,
+  ATTR_NETWORK_EFFECTIVE_TYPE,
+  ATTR_SCREEN_HEIGHT,
+  ATTR_SCREEN_SIZE,
+  ATTR_SCREEN_WIDTH,
+} from './semantic-attributes';
 
 type ScreenSize = 'small' | 'medium' | 'large' | 'unknown';
 
@@ -64,20 +79,20 @@ export function configureBrowserAttributesResource(): Resource {
   );
 
   const browserAttributes: DetectedResourceAttributes = {
-    'user_agent.original': navigator.userAgent,
+    [ATTR_USER_AGENT_ORIGINAL]: navigator.userAgent,
     //https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#mobile_tablet_or_desktop
-    'browser.mobile': navigator.userAgent.includes('Mobi'),
-    'browser.touch_screen_enabled': navigator.maxTouchPoints > 0,
-    'browser.language': navigator.language,
-    'browser.name': browserName,
-    'browser.version': browserVersion,
-    'device.type': deviceType,
-    'network.effectiveType': computeNetworkType(
+    [ATTR_BROWSER_MOBILE]: navigator.userAgent.includes('Mobi'),
+    [ATTR_BROWSER_TOUCH_SCREEN_ENABLED]: navigator.maxTouchPoints > 0,
+    [ATTR_BROWSER_LANGUAGE]: navigator.language,
+    [ATTR_BROWSER_NAME]: browserName,
+    [ATTR_BROWSER_VERSION]: browserVersion,
+    [ATTR_DEVICE_TYPE]: deviceType,
+    [ATTR_NETWORK_EFFECTIVE_TYPE]: computeNetworkType(
       (navigator as ExtendedNavigator).connection,
     ),
-    'screen.width': window.screen.width,
-    'screen.height': window.screen.height,
-    'screen.size': computeScreenSize(window.screen.width),
+    [ATTR_SCREEN_WIDTH]: window.screen.width,
+    [ATTR_SCREEN_HEIGHT]: window.screen.height,
+    [ATTR_SCREEN_SIZE]: computeScreenSize(window.screen.width),
   };
 
   return resourceFromAttributes(browserAttributes);

--- a/packages/honeycomb-opentelemetry-web/src/browser-attributes-span-processor.ts
+++ b/packages/honeycomb-opentelemetry-web/src/browser-attributes-span-processor.ts
@@ -1,5 +1,15 @@
 import { Span } from '@opentelemetry/api';
 import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import {
+  ATTR_BROWSER_HEIGHT,
+  ATTR_BROWSER_WIDTH,
+  ATTR_PAGE_HASH,
+  ATTR_PAGE_HOSTNAME,
+  ATTR_PAGE_ROUTE,
+  ATTR_PAGE_SEARCH,
+  ATTR_PAGE_URL,
+  ATTR_URL_PATH,
+} from './semantic-attributes';
 
 /**
  * A {@link SpanProcessor} that adds browser specific attributes to each span
@@ -13,15 +23,15 @@ export class BrowserAttributesSpanProcessor implements SpanProcessor {
     const { href, pathname, search, hash, hostname } = window.location;
 
     span.setAttributes({
-      'browser.width': window.innerWidth,
-      'browser.height': window.innerHeight,
-      'page.hash': hash,
-      'page.url': href,
-      'page.route': pathname,
-      'page.hostname': hostname,
-      'page.search': search,
+      [ATTR_BROWSER_WIDTH]: window.innerWidth,
+      [ATTR_BROWSER_HEIGHT]: window.innerHeight,
+      [ATTR_PAGE_HASH]: hash,
+      [ATTR_PAGE_URL]: href,
+      [ATTR_PAGE_ROUTE]: pathname,
+      [ATTR_PAGE_HOSTNAME]: hostname,
+      [ATTR_PAGE_SEARCH]: search,
 
-      'url.path': pathname,
+      [ATTR_URL_PATH]: pathname,
     });
   }
 

--- a/packages/honeycomb-opentelemetry-web/src/entry-page-resource.ts
+++ b/packages/honeycomb-opentelemetry-web/src/entry-page-resource.ts
@@ -4,6 +4,14 @@ import {
   resourceFromAttributes,
 } from '@opentelemetry/resources';
 import { EntryPageConfig } from './types';
+import {
+  ATTR_ENTRY_PAGE_HASH,
+  ATTR_ENTRY_PAGE_HOSTNAME,
+  ATTR_ENTRY_PAGE_PATH,
+  ATTR_ENTRY_PAGE_REFERRER,
+  ATTR_ENTRY_PAGE_SEARCH,
+  ATTR_ENTRY_PAGE_URL,
+} from './semantic-attributes';
 
 export const defaultConfig: EntryPageConfig = {
   path: true,
@@ -25,12 +33,12 @@ export function configureEntryPageResource(
   const { href, pathname, search, hash, hostname } = window.location;
 
   const attributes: DetectedResourceAttributes = {
-    'entry_page.url': optionalAttribute(options.url, href),
-    'entry_page.path': optionalAttribute(options.path, pathname),
-    'entry_page.search': optionalAttribute(options.search, search),
-    'entry_page.hash': optionalAttribute(options.hash, hash),
-    'entry_page.hostname': optionalAttribute(options.hostname, hostname),
-    'entry_page.referrer': optionalAttribute(
+    [ATTR_ENTRY_PAGE_URL]: optionalAttribute(options.url, href),
+    [ATTR_ENTRY_PAGE_PATH]: optionalAttribute(options.path, pathname),
+    [ATTR_ENTRY_PAGE_SEARCH]: optionalAttribute(options.search, search),
+    [ATTR_ENTRY_PAGE_HASH]: optionalAttribute(options.hash, hash),
+    [ATTR_ENTRY_PAGE_HOSTNAME]: optionalAttribute(options.hostname, hostname),
+    [ATTR_ENTRY_PAGE_REFERRER]: optionalAttribute(
       options.referrer,
       document.referrer,
     ),

--- a/packages/honeycomb-opentelemetry-web/src/honeycomb-resource.ts
+++ b/packages/honeycomb-opentelemetry-web/src/honeycomb-resource.ts
@@ -4,11 +4,15 @@ import {
   ATTR_TELEMETRY_DISTRO_VERSION,
 } from '@opentelemetry/semantic-conventions/incubating';
 import { VERSION } from './version';
+import {
+  ATTR_HONEYCOMB_DISTRO_RUNTIME_VERSION,
+  ATTR_HONEYCOMB_DISTRO_VERSION,
+} from './semantic-attributes';
 
 export function configureHoneycombResource(): Resource {
   return resourceFromAttributes({
-    'honeycomb.distro.version': VERSION,
-    'honeycomb.distro.runtime_version': 'browser',
+    [ATTR_HONEYCOMB_DISTRO_VERSION]: VERSION,
+    [ATTR_HONEYCOMB_DISTRO_RUNTIME_VERSION]: 'browser',
     [ATTR_TELEMETRY_DISTRO_NAME]: '@honeycombio/opentelemetry-web',
     [ATTR_TELEMETRY_DISTRO_VERSION]: VERSION,
   });

--- a/packages/honeycomb-opentelemetry-web/src/index.ts
+++ b/packages/honeycomb-opentelemetry-web/src/index.ts
@@ -5,3 +5,4 @@ export * from './global-errors-autoinstrumentation';
 export * from './experimental';
 export * from './baggage-span-processor';
 export * from './types';
+export * from './semantic-attributes';

--- a/packages/honeycomb-opentelemetry-web/src/semantic-attributes.ts
+++ b/packages/honeycomb-opentelemetry-web/src/semantic-attributes.ts
@@ -1,0 +1,673 @@
+/**
+ * Custom semantic attribute constants for the Honeycomb OpenTelemetry Web SDK.
+ * These attributes extend the standard OpenTelemetry semantic conventions with
+ * Honeycomb-specific and browser-specific attributes.
+ */
+
+// =============================================================================
+// Browser Attributes
+// =============================================================================
+
+/**
+ * The name of the browser.
+ * @example "Chrome", "Firefox", "Safari"
+ */
+export const ATTR_BROWSER_NAME = 'browser.name';
+
+/**
+ * The version of the browser.
+ * @example "95.0.4638.54"
+ */
+export const ATTR_BROWSER_VERSION = 'browser.version';
+
+/**
+ * Whether the browser has touch screen capabilities.
+ * @example true, false
+ */
+export const ATTR_BROWSER_TOUCH_SCREEN_ENABLED = 'browser.touch_screen_enabled';
+
+/**
+ * The current width of the browser viewport in pixels.
+ * @example 1024
+ */
+export const ATTR_BROWSER_WIDTH = 'browser.width';
+
+/**
+ * The current height of the browser viewport in pixels.
+ * @example 768
+ */
+export const ATTR_BROWSER_HEIGHT = 'browser.height';
+
+// =============================================================================
+// Device Attributes
+// =============================================================================
+
+/**
+ * The type of device.
+ * @example "desktop", "mobile", "tablet"
+ */
+export const ATTR_DEVICE_TYPE = 'device.type';
+
+// =============================================================================
+// Network Attributes
+// =============================================================================
+
+/**
+ * The effective network connection type.
+ * @example "4g", "3g", "2g", "slow-2g", "unknown"
+ */
+export const ATTR_NETWORK_EFFECTIVE_TYPE = 'network.effectiveType';
+
+// =============================================================================
+// Screen Attributes
+// =============================================================================
+
+/**
+ * The width of the screen in pixels.
+ * @example 1920
+ */
+export const ATTR_SCREEN_WIDTH = 'screen.width';
+
+/**
+ * The height of the screen in pixels.
+ * @example 1080
+ */
+export const ATTR_SCREEN_HEIGHT = 'screen.height';
+
+/**
+ * The computed screen size category based on width.
+ * @example "small", "medium", "large", "unknown"
+ */
+export const ATTR_SCREEN_SIZE = 'screen.size';
+
+// =============================================================================
+// Page Attributes
+// =============================================================================
+
+/**
+ * The current page URL hash fragment.
+ * @example "#section1"
+ */
+export const ATTR_PAGE_HASH = 'page.hash';
+
+/**
+ * The current page full URL.
+ * @example "https://example.com/path?query=value#hash"
+ */
+export const ATTR_PAGE_URL = 'page.url';
+
+/**
+ * The current page route/pathname.
+ * @example "/products/123"
+ */
+export const ATTR_PAGE_ROUTE = 'page.route';
+
+/**
+ * The current page hostname.
+ * @example "example.com"
+ */
+export const ATTR_PAGE_HOSTNAME = 'page.hostname';
+
+/**
+ * The current page search parameters.
+ * @example "?query=value&sort=asc"
+ */
+export const ATTR_PAGE_SEARCH = 'page.search';
+
+// =============================================================================
+// URL Attributes
+// =============================================================================
+
+/**
+ * The current URL path.
+ * @example "/products/123"
+ */
+export const ATTR_URL_PATH = 'url.path';
+
+// =============================================================================
+// Entry Page Attributes
+// =============================================================================
+
+/**
+ * The URL of the entry page (page where the session started).
+ * @example "https://example.com/landing?utm_source=google"
+ */
+export const ATTR_ENTRY_PAGE_URL = 'entry_page.url';
+
+/**
+ * The path of the entry page (page where the session started).
+ * @example "/landing"
+ */
+export const ATTR_ENTRY_PAGE_PATH = 'entry_page.path';
+
+/**
+ * The search parameters of the entry page.
+ * @example "?utm_source=google&utm_medium=cpc"
+ */
+export const ATTR_ENTRY_PAGE_SEARCH = 'entry_page.search';
+
+/**
+ * The hash fragment of the entry page.
+ * @example "#welcome"
+ */
+export const ATTR_ENTRY_PAGE_HASH = 'entry_page.hash';
+
+/**
+ * The hostname of the entry page.
+ * @example "example.com"
+ */
+export const ATTR_ENTRY_PAGE_HOSTNAME = 'entry_page.hostname';
+
+/**
+ * The referrer URL that led to the entry page.
+ * @example "https://google.com/search?q=example"
+ */
+export const ATTR_ENTRY_PAGE_REFERRER = 'entry_page.referrer';
+
+// =============================================================================
+// Honeycomb Distro Attributes
+// =============================================================================
+
+/**
+ * The version of the Honeycomb distribution.
+ * @example "1.2.3"
+ */
+export const ATTR_HONEYCOMB_DISTRO_VERSION = 'honeycomb.distro.version';
+
+/**
+ * The runtime version of the Honeycomb distribution.
+ * @example "browser"
+ */
+export const ATTR_HONEYCOMB_DISTRO_RUNTIME_VERSION =
+  'honeycomb.distro.runtime_version';
+
+// =============================================================================
+// Web Vitals Attributes
+// =============================================================================
+
+// CLS (Cumulative Layout Shift) attributes
+/**
+ * CLS metric ID.
+ * @example "v1-123456789"
+ */
+export const ATTR_CLS_ID = 'cls.id';
+
+/**
+ * CLS metric value.
+ * @example 0.123
+ */
+export const ATTR_CLS_VALUE = 'cls.value';
+
+/**
+ * CLS metric delta.
+ * @example 0.045
+ */
+export const ATTR_CLS_DELTA = 'cls.delta';
+
+/**
+ * CLS metric rating.
+ * @example "good", "needs-improvement", "poor"
+ */
+export const ATTR_CLS_RATING = 'cls.rating';
+
+/**
+ * CLS navigation type.
+ * @example "navigate", "reload", "back-forward"
+ */
+export const ATTR_CLS_NAVIGATION_TYPE = 'cls.navigation_type';
+
+// LCP (Largest Contentful Paint) attributes
+/**
+ * LCP metric ID.
+ * @example "v1-123456789"
+ */
+export const ATTR_LCP_ID = 'lcp.id';
+
+/**
+ * LCP metric value.
+ * @example 1234.56
+ */
+export const ATTR_LCP_VALUE = 'lcp.value';
+
+/**
+ * LCP metric delta.
+ * @example 123.45
+ */
+export const ATTR_LCP_DELTA = 'lcp.delta';
+
+/**
+ * LCP metric rating.
+ * @example "good", "needs-improvement", "poor"
+ */
+export const ATTR_LCP_RATING = 'lcp.rating';
+
+/**
+ * LCP navigation type.
+ * @example "navigate", "reload", "back-forward"
+ */
+export const ATTR_LCP_NAVIGATION_TYPE = 'lcp.navigation_type';
+
+// INP (Interaction to Next Paint) attributes
+/**
+ * INP metric ID.
+ * @example "v1-123456789"
+ */
+export const ATTR_INP_ID = 'inp.id';
+
+/**
+ * INP metric value.
+ * @example 89.12
+ */
+export const ATTR_INP_VALUE = 'inp.value';
+
+/**
+ * INP metric delta.
+ * @example 23.45
+ */
+export const ATTR_INP_DELTA = 'inp.delta';
+
+/**
+ * INP metric rating.
+ * @example "good", "needs-improvement", "poor"
+ */
+export const ATTR_INP_RATING = 'inp.rating';
+
+/**
+ * INP navigation type.
+ * @example "navigate", "reload", "back-forward"
+ */
+export const ATTR_INP_NAVIGATION_TYPE = 'inp.navigation_type';
+
+// FCP (First Contentful Paint) attributes
+/**
+ * FCP metric ID.
+ * @example "v1-123456789"
+ */
+export const ATTR_FCP_ID = 'fcp.id';
+
+/**
+ * FCP metric value.
+ * @example 678.90
+ */
+export const ATTR_FCP_VALUE = 'fcp.value';
+
+/**
+ * FCP metric delta.
+ * @example 67.89
+ */
+export const ATTR_FCP_DELTA = 'fcp.delta';
+
+/**
+ * FCP metric rating.
+ * @example "good", "needs-improvement", "poor"
+ */
+export const ATTR_FCP_RATING = 'fcp.rating';
+
+/**
+ * FCP navigation type.
+ * @example "navigate", "reload", "back-forward"
+ */
+export const ATTR_FCP_NAVIGATION_TYPE = 'fcp.navigation_type';
+
+// TTFB (Time to First Byte) attributes
+/**
+ * TTFB metric ID.
+ * @example "v1-123456789"
+ */
+export const ATTR_TTFB_ID = 'ttfb.id';
+
+/**
+ * TTFB metric value.
+ * @example 234.56
+ */
+export const ATTR_TTFB_VALUE = 'ttfb.value';
+
+/**
+ * TTFB metric delta.
+ * @example 34.56
+ */
+export const ATTR_TTFB_DELTA = 'ttfb.delta';
+
+/**
+ * TTFB metric rating.
+ * @example "good", "needs-improvement", "poor"
+ */
+export const ATTR_TTFB_RATING = 'ttfb.rating';
+
+/**
+ * TTFB navigation type.
+ * @example "navigate", "reload", "back-forward"
+ */
+export const ATTR_TTFB_NAVIGATION_TYPE = 'ttfb.navigation_type';
+
+// CLS (Cumulative Layout Shift) specific attributes
+/**
+ * The largest shift target element for CLS.
+ * @example "div.main-content"
+ */
+export const ATTR_CLS_LARGEST_SHIFT_TARGET = 'cls.largest_shift_target';
+
+/**
+ * The element that caused the largest shift for CLS.
+ * @example "div.main-content"
+ */
+export const ATTR_CLS_ELEMENT = 'cls.element';
+
+/**
+ * The time when the largest shift occurred for CLS.
+ * @example 1234.56
+ */
+export const ATTR_CLS_LARGEST_SHIFT_TIME = 'cls.largest_shift_time';
+
+/**
+ * The value of the largest shift for CLS.
+ * @example 0.123
+ */
+export const ATTR_CLS_LARGEST_SHIFT_VALUE = 'cls.largest_shift_value';
+
+/**
+ * The load state when CLS occurred.
+ * @example "complete", "loading"
+ */
+export const ATTR_CLS_LOAD_STATE = 'cls.load_state';
+
+/**
+ * Whether there was recent input before the CLS.
+ * @example true, false
+ */
+export const ATTR_CLS_HAD_RECENT_INPUT = 'cls.had_recent_input';
+
+// LCP (Largest Contentful Paint) specific attributes
+/**
+ * The element that was the largest contentful paint.
+ * @example "img.hero-image"
+ */
+export const ATTR_LCP_ELEMENT = 'lcp.element';
+
+/**
+ * The URL of the resource for LCP.
+ * @example "https://example.com/hero.jpg"
+ */
+export const ATTR_LCP_URL = 'lcp.url';
+
+/**
+ * Time to first byte for LCP.
+ * @example 123.45
+ */
+export const ATTR_LCP_TIME_TO_FIRST_BYTE = 'lcp.time_to_first_byte';
+
+/**
+ * Resource load delay for LCP.
+ * @example 45.67
+ */
+export const ATTR_LCP_RESOURCE_LOAD_DELAY = 'lcp.resource_load_delay';
+
+/**
+ * Resource load duration for LCP.
+ * @example 89.12
+ */
+export const ATTR_LCP_RESOURCE_LOAD_DURATION = 'lcp.resource_load_duration';
+
+/**
+ * Element render delay for LCP.
+ * @example 12.34
+ */
+export const ATTR_LCP_ELEMENT_RENDER_DELAY = 'lcp.element_render_delay';
+
+/**
+ * Resource load time for LCP (deprecated, use resource_load_duration).
+ * @example 89.12
+ * @deprecated Use ATTR_LCP_RESOURCE_LOAD_DURATION instead
+ */
+export const ATTR_LCP_RESOURCE_LOAD_TIME = 'lcp.resource_load_time';
+
+// INP (Interaction to Next Paint) specific attributes
+/**
+ * Input delay for INP.
+ * @example 12.34
+ */
+export const ATTR_INP_INPUT_DELAY = 'inp.input_delay';
+
+/**
+ * Interaction target for INP.
+ * @example "button.submit"
+ */
+export const ATTR_INP_INTERACTION_TARGET = 'inp.interaction_target';
+
+/**
+ * Interaction time for INP.
+ * @example 1234567890123
+ */
+export const ATTR_INP_INTERACTION_TIME = 'inp.interaction_time';
+
+/**
+ * Interaction type for INP.
+ * @example "click", "keydown"
+ */
+export const ATTR_INP_INTERACTION_TYPE = 'inp.interaction_type';
+
+/**
+ * Load state when INP occurred.
+ * @example "complete", "loading"
+ */
+export const ATTR_INP_LOAD_STATE = 'inp.load_state';
+
+/**
+ * Next paint time for INP.
+ * @example 1234567890234
+ */
+export const ATTR_INP_NEXT_PAINT_TIME = 'inp.next_paint_time';
+
+/**
+ * Presentation delay for INP.
+ * @example 23.45
+ */
+export const ATTR_INP_PRESENTATION_DELAY = 'inp.presentation_delay';
+
+/**
+ * Processing duration for INP.
+ * @example 34.56
+ */
+export const ATTR_INP_PROCESSING_DURATION = 'inp.processing_duration';
+
+/**
+ * Total duration for INP.
+ * @example 70.35
+ */
+export const ATTR_INP_DURATION = 'inp.duration';
+
+/**
+ * Element for INP (deprecated, use interaction_target).
+ * @example "button.submit"
+ * @deprecated Use ATTR_INP_INTERACTION_TARGET instead
+ */
+export const ATTR_INP_ELEMENT = 'inp.element';
+
+/**
+ * Event type for INP (deprecated, use interaction_type).
+ * @example "click"
+ * @deprecated Use ATTR_INP_INTERACTION_TYPE instead
+ */
+export const ATTR_INP_EVENT_TYPE = 'inp.event_type';
+
+// INP Script Timing attributes
+/**
+ * Script entry type for INP timing.
+ * @example "script"
+ */
+export const ATTR_INP_SCRIPT_ENTRY_TYPE = 'inp.timing.script.entry_type';
+
+/**
+ * Script start time for INP timing.
+ * @example 1234567890123
+ */
+export const ATTR_INP_SCRIPT_START_TIME = 'inp.timing.script.start_time';
+
+/**
+ * Script execution start for INP timing.
+ * @example 1234567890125
+ */
+export const ATTR_INP_SCRIPT_EXECUTION_START =
+  'inp.timing.script.execution_start';
+
+/**
+ * Script duration for INP timing.
+ * @example 45.67
+ */
+export const ATTR_INP_SCRIPT_DURATION = 'inp.timing.script.duration';
+
+/**
+ * Script forced style and layout duration for INP timing.
+ * @example 12.34
+ */
+export const ATTR_INP_SCRIPT_FORCED_STYLE_AND_LAYOUT_DURATION =
+  'inp.timing.script.forced_style_and_layout_duration';
+
+/**
+ * Script invoker for INP timing.
+ * @example "event-listener"
+ */
+export const ATTR_INP_SCRIPT_INVOKER = 'inp.timing.script.invoker';
+
+/**
+ * Script pause duration for INP timing.
+ * @example 5.67
+ */
+export const ATTR_INP_SCRIPT_PAUSE_DURATION =
+  'inp.timing.script.pause_duration';
+
+/**
+ * Script source URL for INP timing.
+ * @example "https://example.com/script.js"
+ */
+export const ATTR_INP_SCRIPT_SOURCE_URL = 'inp.timing.script.source_url';
+
+/**
+ * Script source function name for INP timing.
+ * @example "handleClick"
+ */
+export const ATTR_INP_SCRIPT_SOURCE_FUNCTION_NAME =
+  'inp.timing.script.source_function_name';
+
+/**
+ * Script source character position for INP timing.
+ * @example 123
+ */
+export const ATTR_INP_SCRIPT_SOURCE_CHAR_POSITION =
+  'inp.timing.script.source_char_position';
+
+/**
+ * Script window attribution for INP timing.
+ * @example "self"
+ */
+export const ATTR_INP_SCRIPT_WINDOW_ATTRIBUTION =
+  'inp.timing.script.window_attribution';
+
+// INP Long Animation Frame Timing attributes
+/**
+ * Long animation frame duration for INP timing.
+ * @example 123.45
+ */
+export const ATTR_INP_TIMING_DURATION = 'inp.timing.duration';
+
+/**
+ * Long animation frame entry type for INP timing.
+ * @example "long-animation-frame"
+ */
+export const ATTR_INP_TIMING_ENTRY_TYPE = 'inp.timing.entryType';
+
+/**
+ * Long animation frame name for INP timing.
+ * @example "same-origin-descendant"
+ */
+export const ATTR_INP_TIMING_NAME = 'inp.timing.name';
+
+/**
+ * Long animation frame render start for INP timing.
+ * @example 1234567890234
+ */
+export const ATTR_INP_TIMING_RENDER_START = 'inp.timing.renderStart';
+
+/**
+ * Long animation frame start time for INP timing.
+ * @example 1234567890123
+ */
+export const ATTR_INP_TIMING_START_TIME = 'inp.timing.startTime';
+
+// FCP (First Contentful Paint) specific attributes
+/**
+ * Time to first byte for FCP.
+ * @example 123.45
+ */
+export const ATTR_FCP_TIME_TO_FIRST_BYTE = 'fcp.time_to_first_byte';
+
+/**
+ * Time since first byte for FCP.
+ * @example 67.89
+ */
+export const ATTR_FCP_TIME_SINCE_FIRST_BYTE = 'fcp.time_since_first_byte';
+
+/**
+ * Load state when FCP occurred.
+ * @example "complete", "loading"
+ */
+export const ATTR_FCP_LOAD_STATE = 'fcp.load_state';
+
+// TTFB (Time to First Byte) specific attributes
+/**
+ * Waiting duration for TTFB.
+ * @example 45.67
+ */
+export const ATTR_TTFB_WAITING_DURATION = 'ttfb.waiting_duration';
+
+/**
+ * DNS duration for TTFB.
+ * @example 12.34
+ */
+export const ATTR_TTFB_DNS_DURATION = 'ttfb.dns_duration';
+
+/**
+ * Connection duration for TTFB.
+ * @example 23.45
+ */
+export const ATTR_TTFB_CONNECTION_DURATION = 'ttfb.connection_duration';
+
+/**
+ * Request duration for TTFB.
+ * @example 34.56
+ */
+export const ATTR_TTFB_REQUEST_DURATION = 'ttfb.request_duration';
+
+/**
+ * Cache duration for TTFB.
+ * @example 5.67
+ */
+export const ATTR_TTFB_CACHE_DURATION = 'ttfb.cache_duration';
+
+/**
+ * Waiting time for TTFB (deprecated, use waiting_duration).
+ * @example 45.67
+ * @deprecated Use ATTR_TTFB_WAITING_DURATION instead
+ */
+export const ATTR_TTFB_WAITING_TIME = 'ttfb.waiting_time';
+
+/**
+ * DNS time for TTFB (deprecated, use dns_duration).
+ * @example 12.34
+ * @deprecated Use ATTR_TTFB_DNS_DURATION instead
+ */
+export const ATTR_TTFB_DNS_TIME = 'ttfb.dns_time';
+
+/**
+ * Connection time for TTFB (deprecated, use connection_duration).
+ * @example 23.45
+ * @deprecated Use ATTR_TTFB_CONNECTION_DURATION instead
+ */
+export const ATTR_TTFB_CONNECTION_TIME = 'ttfb.connection_time';
+
+/**
+ * Request time for TTFB (deprecated, use request_duration).
+ * @example 34.56
+ * @deprecated Use ATTR_TTFB_REQUEST_DURATION instead
+ */
+export const ATTR_TTFB_REQUEST_TIME = 'ttfb.request_time';

--- a/packages/honeycomb-opentelemetry-web/src/semantic-attributes.ts
+++ b/packages/honeycomb-opentelemetry-web/src/semantic-attributes.ts
@@ -2,6 +2,8 @@
  * Custom semantic attribute constants for the Honeycomb OpenTelemetry Web SDK.
  * These attributes extend the standard OpenTelemetry semantic conventions with
  * Honeycomb-specific and browser-specific attributes.
+ *
+ * https://github.com/open-telemetry/semantic-conventions/tree/main/model/browser
  */
 
 // =============================================================================

--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -34,6 +34,85 @@ import {
   TracerProvider,
 } from '@opentelemetry/api';
 import * as shimmer from 'shimmer';
+import {
+  ATTR_CLS_DELTA,
+  ATTR_CLS_ELEMENT,
+  ATTR_CLS_HAD_RECENT_INPUT,
+  ATTR_CLS_ID,
+  ATTR_CLS_LARGEST_SHIFT_TARGET,
+  ATTR_CLS_LARGEST_SHIFT_TIME,
+  ATTR_CLS_LARGEST_SHIFT_VALUE,
+  ATTR_CLS_LOAD_STATE,
+  ATTR_CLS_NAVIGATION_TYPE,
+  ATTR_CLS_RATING,
+  ATTR_CLS_VALUE,
+  ATTR_FCP_DELTA,
+  ATTR_FCP_ID,
+  ATTR_FCP_LOAD_STATE,
+  ATTR_FCP_NAVIGATION_TYPE,
+  ATTR_FCP_RATING,
+  ATTR_FCP_TIME_SINCE_FIRST_BYTE,
+  ATTR_FCP_TIME_TO_FIRST_BYTE,
+  ATTR_FCP_VALUE,
+  ATTR_INP_DELTA,
+  ATTR_INP_DURATION,
+  ATTR_INP_ELEMENT,
+  ATTR_INP_EVENT_TYPE,
+  ATTR_INP_ID,
+  ATTR_INP_INPUT_DELAY,
+  ATTR_INP_INTERACTION_TARGET,
+  ATTR_INP_INTERACTION_TIME,
+  ATTR_INP_INTERACTION_TYPE,
+  ATTR_INP_LOAD_STATE,
+  ATTR_INP_NAVIGATION_TYPE,
+  ATTR_INP_NEXT_PAINT_TIME,
+  ATTR_INP_PRESENTATION_DELAY,
+  ATTR_INP_PROCESSING_DURATION,
+  ATTR_INP_RATING,
+  ATTR_INP_SCRIPT_DURATION,
+  ATTR_INP_SCRIPT_ENTRY_TYPE,
+  ATTR_INP_SCRIPT_EXECUTION_START,
+  ATTR_INP_SCRIPT_FORCED_STYLE_AND_LAYOUT_DURATION,
+  ATTR_INP_SCRIPT_INVOKER,
+  ATTR_INP_SCRIPT_PAUSE_DURATION,
+  ATTR_INP_SCRIPT_SOURCE_CHAR_POSITION,
+  ATTR_INP_SCRIPT_SOURCE_FUNCTION_NAME,
+  ATTR_INP_SCRIPT_SOURCE_URL,
+  ATTR_INP_SCRIPT_START_TIME,
+  ATTR_INP_SCRIPT_WINDOW_ATTRIBUTION,
+  ATTR_INP_TIMING_DURATION,
+  ATTR_INP_TIMING_ENTRY_TYPE,
+  ATTR_INP_TIMING_NAME,
+  ATTR_INP_TIMING_RENDER_START,
+  ATTR_INP_TIMING_START_TIME,
+  ATTR_INP_VALUE,
+  ATTR_LCP_DELTA,
+  ATTR_LCP_ELEMENT,
+  ATTR_LCP_ELEMENT_RENDER_DELAY,
+  ATTR_LCP_ID,
+  ATTR_LCP_NAVIGATION_TYPE,
+  ATTR_LCP_RATING,
+  ATTR_LCP_RESOURCE_LOAD_DELAY,
+  ATTR_LCP_RESOURCE_LOAD_DURATION,
+  ATTR_LCP_RESOURCE_LOAD_TIME,
+  ATTR_LCP_TIME_TO_FIRST_BYTE,
+  ATTR_LCP_URL,
+  ATTR_LCP_VALUE,
+  ATTR_TTFB_CACHE_DURATION,
+  ATTR_TTFB_CONNECTION_DURATION,
+  ATTR_TTFB_CONNECTION_TIME,
+  ATTR_TTFB_DELTA,
+  ATTR_TTFB_DNS_DURATION,
+  ATTR_TTFB_DNS_TIME,
+  ATTR_TTFB_ID,
+  ATTR_TTFB_NAVIGATION_TYPE,
+  ATTR_TTFB_RATING,
+  ATTR_TTFB_REQUEST_DURATION,
+  ATTR_TTFB_REQUEST_TIME,
+  ATTR_TTFB_VALUE,
+  ATTR_TTFB_WAITING_DURATION,
+  ATTR_TTFB_WAITING_TIME,
+} from './semantic-attributes';
 
 type ApplyCustomAttributesFn = (vital: Metric, span: Span) => void;
 
@@ -284,49 +363,37 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
     return name.toLowerCase();
   }
 
-  private getSharedAttributes(vital: Metric) {
-    const { name, id, delta, rating, value, navigationType } = vital;
-    const attrPrefix = this.getAttrPrefix(name);
-    return {
-      [`${attrPrefix}.id`]: id,
-      [`${attrPrefix}.delta`]: delta,
-      [`${attrPrefix}.value`]: value,
-      [`${attrPrefix}.rating`]: rating,
-      [`${attrPrefix}.navigation_type`]: navigationType,
-    };
-  }
-
   private getAttributesForPerformanceLongAnimationFrameTiming(
-    prefix: string,
     perfEntry: PerformanceLongAnimationFrameTiming,
   ) {
     const loafAttributes = {
-      [`${prefix}.duration`]: perfEntry.duration,
-      [`${prefix}.entryType`]: perfEntry.entryType,
-      [`${prefix}.name`]: perfEntry.name,
-      [`${prefix}.renderStart`]: perfEntry.renderStart,
-      [`${prefix}.startTime`]: perfEntry.startTime,
+      [ATTR_INP_TIMING_DURATION]: perfEntry.duration,
+      [ATTR_INP_TIMING_ENTRY_TYPE]: perfEntry.entryType,
+      [ATTR_INP_TIMING_NAME]: perfEntry.name,
+      [ATTR_INP_TIMING_RENDER_START]: perfEntry.renderStart,
+      [ATTR_INP_TIMING_START_TIME]: perfEntry.startTime,
     };
     return loafAttributes;
   }
 
   private getAttributesForPerformanceScriptTiming(
-    prefix: string,
     scriptPerfEntry: PerformanceScriptTiming,
   ) {
     const scriptAttributes = {
-      [`${prefix}.entry_type`]: scriptPerfEntry.entryType,
-      [`${prefix}.start_time`]: scriptPerfEntry.startTime,
-      [`${prefix}.execution_start`]: scriptPerfEntry.executionStart,
-      [`${prefix}.duration`]: scriptPerfEntry.duration,
-      [`${prefix}.forced_style_and_layout_duration`]:
+      [ATTR_INP_SCRIPT_ENTRY_TYPE]: scriptPerfEntry.entryType,
+      [ATTR_INP_SCRIPT_START_TIME]: scriptPerfEntry.startTime,
+      [ATTR_INP_SCRIPT_EXECUTION_START]: scriptPerfEntry.executionStart,
+      [ATTR_INP_SCRIPT_DURATION]: scriptPerfEntry.duration,
+      [ATTR_INP_SCRIPT_FORCED_STYLE_AND_LAYOUT_DURATION]:
         scriptPerfEntry.forcedStyleAndLayoutDuration,
-      [`${prefix}.invoker`]: scriptPerfEntry.invoker,
-      [`${prefix}.pause_duration`]: scriptPerfEntry.pauseDuration,
-      [`${prefix}.source_url`]: scriptPerfEntry.sourceURL,
-      [`${prefix}.source_function_name`]: scriptPerfEntry.sourceFunctionName,
-      [`${prefix}.source_char_position`]: scriptPerfEntry.sourceCharPosition,
-      [`${prefix}.window_attribution`]: scriptPerfEntry.windowAttribution,
+      [ATTR_INP_SCRIPT_INVOKER]: scriptPerfEntry.invoker,
+      [ATTR_INP_SCRIPT_PAUSE_DURATION]: scriptPerfEntry.pauseDuration,
+      [ATTR_INP_SCRIPT_SOURCE_URL]: scriptPerfEntry.sourceURL,
+      [ATTR_INP_SCRIPT_SOURCE_FUNCTION_NAME]:
+        scriptPerfEntry.sourceFunctionName,
+      [ATTR_INP_SCRIPT_SOURCE_CHAR_POSITION]:
+        scriptPerfEntry.sourceCharPosition,
+      [ATTR_INP_SCRIPT_WINDOW_ATTRIBUTION]: scriptPerfEntry.windowAttribution,
     };
     return scriptAttributes;
   }
@@ -337,18 +404,17 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
   ) {
     if (!perfEntry) return;
 
-    const prefix = `${parentPrefix}.timing`;
     const loafAttributes =
-      this.getAttributesForPerformanceLongAnimationFrameTiming(
-        prefix,
-        perfEntry,
-      );
+      this.getAttributesForPerformanceLongAnimationFrameTiming(perfEntry);
     this.tracer.startActiveSpan(
       perfEntry.name,
       { startTime: perfEntry.startTime },
       (span) => {
         span.setAttributes(loafAttributes);
-        this.processPerformanceScriptTimingSpans(prefix, perfEntry.scripts);
+        this.processPerformanceScriptTimingSpans(
+          parentPrefix,
+          perfEntry.scripts,
+        );
         span.end(perfEntry.startTime + perfEntry.duration);
       },
     );
@@ -360,17 +426,14 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
   ) {
     if (!perfScriptEntries) return;
     if (!perfScriptEntries?.length) return;
-    const prefix = `${parentPrefix}.script`;
 
     perfScriptEntries.map((scriptPerfEntry) => {
       this.tracer.startActiveSpan(
         scriptPerfEntry.name,
         { startTime: scriptPerfEntry.startTime },
         (span) => {
-          const scriptAttributes = this.getAttributesForPerformanceScriptTiming(
-            prefix,
-            scriptPerfEntry,
-          );
+          const scriptAttributes =
+            this.getAttributesForPerformanceScriptTiming(scriptPerfEntry);
           span.setAttributes(scriptAttributes);
           span.end(scriptPerfEntry.startTime + scriptPerfEntry.duration);
         },
@@ -425,17 +488,20 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       loadState,
       largestShiftEntry,
     }: CLSAttribution = attribution;
-    const attrPrefix = this.getAttrPrefix(name);
 
     const span = this.tracer.startSpan(name);
     span.setAttributes({
-      ...this.getSharedAttributes(cls),
-      [`${attrPrefix}.largest_shift_target`]: largestShiftTarget,
-      [`${attrPrefix}.element`]: largestShiftTarget,
-      [`${attrPrefix}.largest_shift_time`]: largestShiftTime,
-      [`${attrPrefix}.largest_shift_value`]: largestShiftValue,
-      [`${attrPrefix}.load_state`]: loadState,
-      [`${attrPrefix}.had_recent_input`]: largestShiftEntry?.hadRecentInput,
+      [ATTR_CLS_ID]: cls.id,
+      [ATTR_CLS_DELTA]: cls.delta,
+      [ATTR_CLS_VALUE]: cls.value,
+      [ATTR_CLS_RATING]: cls.rating,
+      [ATTR_CLS_NAVIGATION_TYPE]: cls.navigationType,
+      [ATTR_CLS_LARGEST_SHIFT_TARGET]: largestShiftTarget,
+      [ATTR_CLS_ELEMENT]: largestShiftTarget,
+      [ATTR_CLS_LARGEST_SHIFT_TIME]: largestShiftTime,
+      [ATTR_CLS_LARGEST_SHIFT_VALUE]: largestShiftValue,
+      [ATTR_CLS_LOAD_STATE]: loadState,
+      [ATTR_CLS_HAD_RECENT_INPUT]: largestShiftEntry?.hadRecentInput,
     });
 
     if (applyCustomAttributes) {
@@ -459,22 +525,25 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       elementRenderDelay,
       lcpEntry,
     }: LCPAttribution = attribution;
-    const attrPrefix = this.getAttrPrefix(name);
 
     const span = this.tracer.startSpan(name);
     span.setAttributes({
-      ...this.getSharedAttributes(lcp),
-      [`${attrPrefix}.element`]: target,
-      [`${attrPrefix}.url`]: url,
-      [`${attrPrefix}.time_to_first_byte`]: timeToFirstByte,
-      [`${attrPrefix}.resource_load_delay`]: resourceLoadDelay,
-      [`${attrPrefix}.resource_load_duration`]: resourceLoadDuration,
-      [`${attrPrefix}.element_render_delay`]: elementRenderDelay,
+      [ATTR_LCP_ID]: lcp.id,
+      [ATTR_LCP_DELTA]: lcp.delta,
+      [ATTR_LCP_VALUE]: lcp.value,
+      [ATTR_LCP_RATING]: lcp.rating,
+      [ATTR_LCP_NAVIGATION_TYPE]: lcp.navigationType,
+      [ATTR_LCP_ELEMENT]: target,
+      [ATTR_LCP_URL]: url,
+      [ATTR_LCP_TIME_TO_FIRST_BYTE]: timeToFirstByte,
+      [ATTR_LCP_RESOURCE_LOAD_DELAY]: resourceLoadDelay,
+      [ATTR_LCP_RESOURCE_LOAD_DURATION]: resourceLoadDuration,
+      [ATTR_LCP_ELEMENT_RENDER_DELAY]: elementRenderDelay,
       // This will be deprecated in a future version
-      [`${attrPrefix}.resource_load_time`]: resourceLoadDuration,
+      [ATTR_LCP_RESOURCE_LOAD_TIME]: resourceLoadDuration,
     });
 
-    this.addDataAttributes(lcpEntry?.element, span, dataAttributes, attrPrefix);
+    this.addDataAttributes(lcpEntry?.element, span, dataAttributes, 'lcp');
 
     if (applyCustomAttributes) {
       applyCustomAttributes(lcp, span);
@@ -504,26 +573,29 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       longAnimationFrameEntries,
     }: INPAttribution = attribution;
 
-    const attrPrefix = this.getAttrPrefix(name);
     const inpDuration = inputDelay + processingDuration + presentationDelay;
     this.tracer.startActiveSpan(
       name,
       { startTime: interactionTime },
       (inpSpan) => {
         const inpAttributes = {
-          ...this.getSharedAttributes(inp),
-          [`${attrPrefix}.input_delay`]: inputDelay,
-          [`${attrPrefix}.interaction_target`]: interactionTarget,
-          [`${attrPrefix}.interaction_time`]: interactionTime,
-          [`${attrPrefix}.interaction_type`]: interactionType,
-          [`${attrPrefix}.load_state`]: loadState,
-          [`${attrPrefix}.next_paint_time`]: nextPaintTime,
-          [`${attrPrefix}.presentation_delay`]: presentationDelay,
-          [`${attrPrefix}.processing_duration`]: processingDuration,
-          [`${attrPrefix}.duration`]: inpDuration,
+          [ATTR_INP_ID]: inp.id,
+          [ATTR_INP_DELTA]: inp.delta,
+          [ATTR_INP_VALUE]: inp.value,
+          [ATTR_INP_RATING]: inp.rating,
+          [ATTR_INP_NAVIGATION_TYPE]: inp.navigationType,
+          [ATTR_INP_INPUT_DELAY]: inputDelay,
+          [ATTR_INP_INTERACTION_TARGET]: interactionTarget,
+          [ATTR_INP_INTERACTION_TIME]: interactionTime,
+          [ATTR_INP_INTERACTION_TYPE]: interactionType,
+          [ATTR_INP_LOAD_STATE]: loadState,
+          [ATTR_INP_NEXT_PAINT_TIME]: nextPaintTime,
+          [ATTR_INP_PRESENTATION_DELAY]: presentationDelay,
+          [ATTR_INP_PROCESSING_DURATION]: processingDuration,
+          [ATTR_INP_DURATION]: inpDuration,
           // These will be deprecated in a future version
-          [`${attrPrefix}.element`]: interactionTarget,
-          [`${attrPrefix}.event_type`]: interactionType,
+          [ATTR_INP_ELEMENT]: interactionTarget,
+          [ATTR_INP_EVENT_TYPE]: interactionType,
         };
 
         inpSpan.setAttributes(inpAttributes);
@@ -532,7 +604,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
             this.getElementFromNode(inpEntry.target),
             inpSpan,
             dataAttributes,
-            attrPrefix,
+            'inp',
           );
         });
         if (applyCustomAttributes) {
@@ -542,7 +614,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
         if (includeTimingsAsSpans) {
           longAnimationFrameEntries.forEach((perfEntry) => {
             this.processPerformanceLongAnimationFrameTimingSpans(
-              attrPrefix,
+              'inp',
               perfEntry,
             );
           });
@@ -559,15 +631,18 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
     const { name, attribution } = fcp;
     const { timeToFirstByte, firstByteToFCP, loadState }: FCPAttribution =
       attribution;
-    const attrPrefix = this.getAttrPrefix(name);
 
     const span = this.tracer.startSpan(name);
 
     span.setAttributes({
-      ...this.getSharedAttributes(fcp),
-      [`${attrPrefix}.time_to_first_byte`]: timeToFirstByte,
-      [`${attrPrefix}.time_since_first_byte`]: firstByteToFCP,
-      [`${attrPrefix}.load_state`]: loadState,
+      [ATTR_FCP_ID]: fcp.id,
+      [ATTR_FCP_DELTA]: fcp.delta,
+      [ATTR_FCP_VALUE]: fcp.value,
+      [ATTR_FCP_RATING]: fcp.rating,
+      [ATTR_FCP_NAVIGATION_TYPE]: fcp.navigationType,
+      [ATTR_FCP_TIME_TO_FIRST_BYTE]: timeToFirstByte,
+      [ATTR_FCP_TIME_SINCE_FIRST_BYTE]: firstByteToFCP,
+      [ATTR_FCP_LOAD_STATE]: loadState,
     });
 
     if (applyCustomAttributes) {
@@ -592,19 +667,22 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       requestDuration,
       waitingDuration,
     }: TTFBAttribution = attribution;
-    const attrPrefix = this.getAttrPrefix(name);
     const attributes = {
-      ...this.getSharedAttributes(ttfb),
-      [`${attrPrefix}.waiting_duration`]: waitingDuration,
-      [`${attrPrefix}.dns_duration`]: dnsDuration,
-      [`${attrPrefix}.connection_duration`]: connectionDuration,
-      [`${attrPrefix}.request_duration`]: requestDuration,
-      [`${attrPrefix}.cache_duration`]: cacheDuration,
+      [ATTR_TTFB_ID]: ttfb.id,
+      [ATTR_TTFB_DELTA]: ttfb.delta,
+      [ATTR_TTFB_VALUE]: ttfb.value,
+      [ATTR_TTFB_RATING]: ttfb.rating,
+      [ATTR_TTFB_NAVIGATION_TYPE]: ttfb.navigationType,
+      [ATTR_TTFB_WAITING_DURATION]: waitingDuration,
+      [ATTR_TTFB_DNS_DURATION]: dnsDuration,
+      [ATTR_TTFB_CONNECTION_DURATION]: connectionDuration,
+      [ATTR_TTFB_REQUEST_DURATION]: requestDuration,
+      [ATTR_TTFB_CACHE_DURATION]: cacheDuration,
       // These will be deprecated ina future version
-      [`${attrPrefix}.waiting_time`]: waitingDuration,
-      [`${attrPrefix}.dns_time`]: dnsDuration,
-      [`${attrPrefix}.connection_time`]: connectionDuration,
-      [`${attrPrefix}.request_time`]: requestDuration,
+      [ATTR_TTFB_WAITING_TIME]: waitingDuration,
+      [ATTR_TTFB_DNS_TIME]: dnsDuration,
+      [ATTR_TTFB_CONNECTION_TIME]: connectionDuration,
+      [ATTR_TTFB_REQUEST_TIME]: requestDuration,
     };
 
     const span = this.tracer.startSpan(name);


### PR DESCRIPTION
## Which problem is this PR solving?
Exports all attribute names introduced by the distro as constants to be used both internally and externally by users.

## Short description of the changes
- added a semantic-attributes.ts file with every attribute name as a constant similar to the OpenTelemetry semantic conventions attribute files
- used these constants internally in the distro instead of hard coded strings.

## How to verify that this has the expected result
- tests pass
- smoke tests pass
