### PR TITLE
fix: export experimental user interaction instrumentation

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/index.ts
+++ b/packages/honeycomb-opentelemetry-web/src/index.ts
@@ -157,3 +157,5 @@ export {
   ATTR_TTFB_WAITING_DURATION,
   ATTR_TTFB_WAITING_TIME,
 } from './semantic-attributes';
+
+export { UserInteractionInstrumentation } from './experimental/user-interaction-instrumentation/user-interaction-instrumentation';


### PR DESCRIPTION
## Which problem is this PR solving?
Got a user report of a breaking change where `UserInteractionInstrumentation` was no longer able to be imported because it isn't included in the named exports.

## Short description of the changes
Add `UserInteractionInstrumentation` to the list of named exports.
