### PR TITLE
docs: Add documentation for sending data to EU instance

### DIFF
--- a/packages/honeycomb-opentelemetry-web/README.md
+++ b/packages/honeycomb-opentelemetry-web/README.md
@@ -51,16 +51,13 @@ import { HoneycombWebSDK, WebVitalsInstrumentation } from '@honeycombio/opentele
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 
 const sdk = new HoneycombWebSDK({
+  // endpoint: "https://api.eu1.honeycomb.io/v1/traces", // Send to EU instance of Honeycomb. Defaults to sending to US instance.
   apiKey: 'api-key-goes-here',
   serviceName: 'your-great-browser-application',
   instrumentations: [getWebAutoInstrumentations(), new WebVitalsInstrumentation()], // add automatic instrumentation
 });
 sdk.start();
 ```
-
-> ### EU instance
-> The SDK sends data to the North America instance of honeycomb by default. If your team is set up in the EU instance add the following field to your SDK.
-> `endpoint: "https://ui.eu1.honeycomb.io"`
 
 4. Build and run your application, and then look for data in Honeycomb. On the Home screen, choose your application by looking for the service name in the Dataset dropdown at the top. Data should populate.
 

--- a/packages/honeycomb-opentelemetry-web/README.md
+++ b/packages/honeycomb-opentelemetry-web/README.md
@@ -58,6 +58,10 @@ const sdk = new HoneycombWebSDK({
 sdk.start();
 ```
 
+> ### EU instance
+> The SDK sends data to the North America instance of honeycomb by default. If your team is set up in the EU instance add the following field to your SDK.
+> `endpoint: "https://ui.eu1.honeycomb.io"`
+
 4. Build and run your application, and then look for data in Honeycomb. On the Home screen, choose your application by looking for the service name in the Dataset dropdown at the top. Data should populate.
 
 ![Honeycomb screen, with "Home" circled on the left, and the dropdown circled at the top.](docs/honeycomb-home.png)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
By default our SDK will send data to the North America instance. As many customers use the European Union instance we need documentation on how to send data there.

- Closes #<enter issue here>

## Short description of the changes
Adds an aside in `getting started` with information on setting the `endpoint` property to the eu instance.

## How to verify that this has the expected result
