### PR TITLE
fix: fix instrumentation to get correct tracer

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/base-otel-sdk.ts
+++ b/packages/honeycomb-opentelemetry-web/src/base-otel-sdk.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { ContextManager, metrics, TextMapPropagator } from '@opentelemetry/api';
+import { ContextManager, metrics, TextMapPropagator, trace } from '@opentelemetry/api';
 import {
   Instrumentation,
   registerInstrumentations,
@@ -169,10 +169,6 @@ export class WebSDK {
       return;
     }
 
-    registerInstrumentations({
-      instrumentations: this._instrumentations,
-    });
-
     if (this._autoDetectResources) {
       const internalConfig: ResourceDetectionConfig = {
         detectors: this._resourceDetectors,
@@ -220,6 +216,7 @@ export class WebSDK {
       contextManager: this._tracerProviderConfig?.contextManager,
       propagator: this._tracerProviderConfig?.textMapPropagator,
     });
+    trace.setGlobalTracerProvider(tracerProvider);
 
     if (this._meterProviderConfig) {
       const readers = this._meterProviderConfig.metricExporters.map(
@@ -246,6 +243,10 @@ export class WebSDK {
       });
       logs.setGlobalLoggerProvider(this._loggerProvider);
     }
+
+    registerInstrumentations({
+      instrumentations: this._instrumentations,
+    });
   }
 
   /* Experimental getter method: not currently part of the upstream

--- a/packages/honeycomb-opentelemetry-web/src/base-otel-sdk.ts
+++ b/packages/honeycomb-opentelemetry-web/src/base-otel-sdk.ts
@@ -17,7 +17,12 @@
  * limitations under the License.
  */
 
-import { ContextManager, metrics, TextMapPropagator, trace } from '@opentelemetry/api';
+import {
+  ContextManager,
+  metrics,
+  TextMapPropagator,
+  trace,
+} from '@opentelemetry/api';
 import {
   Instrumentation,
   registerInstrumentations,


### PR DESCRIPTION
## Which problem is this PR solving?

Before this change, Instrumentation is initialized before the default tracer is constructed, so that the instrumentation's `tracer` property won't work. This fixes it.

## Short description of the changes

1. Set the default tracer as the global tracer.
2. Move instrumentation initialization until after that tracer is created.

## How to verify that this has the expected result

* Smoke tests still pass.
* I manually tested with the React Native repo that the `tracer` property on instrumentation fails before and works after this change.