### PR TITLE
fix: remove redundant call to setGlobalTracerProvider as its set upon creation.

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/base-otel-sdk.ts
+++ b/packages/honeycomb-opentelemetry-web/src/base-otel-sdk.ts
@@ -17,12 +17,7 @@
  * limitations under the License.
  */
 
-import {
-  ContextManager,
-  metrics,
-  TextMapPropagator,
-  trace,
-} from '@opentelemetry/api';
+import { ContextManager, metrics, TextMapPropagator } from '@opentelemetry/api';
 import {
   Instrumentation,
   registerInstrumentations,
@@ -221,7 +216,6 @@ export class WebSDK {
       contextManager: this._tracerProviderConfig?.contextManager,
       propagator: this._tracerProviderConfig?.textMapPropagator,
     });
-    trace.setGlobalTracerProvider(tracerProvider);
 
     if (this._meterProviderConfig) {
       const readers = this._meterProviderConfig.metricExporters.map(


### PR DESCRIPTION
… creation.

<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes  https://github.com/honeycombio/honeycomb-opentelemetry-web/issues/612

## Short description of the changes
`setGlobalTracerProvider` is called as a side effect of `new WebTracerProvider(...)` we don't need to do this manulally.

## How to verify that this has the expected result
See that the console error is no longer appearing. 