### PR TITLE
rel: Releasing honeycomb-opentelemetry-web-v1.1.0

### DIFF
--- a/packages/honeycomb-opentelemetry-web/CHANGELOG.md
+++ b/packages/honeycomb-opentelemetry-web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # honeycomb-opentelemetry-web changelog
 
+## v1.1.0 - 2025-10-24
+
+- feat: Add options metricExporters and disableDefaultMetricExporter (#605) | @sodabrew
+- feat: expose session provider and OpenTelemetry APIs in CDN wrapper (#614) | @wolfgangcodes
+- fix: remove redundant call to setGlobalTracerProvider as its set upon creation. (#615) | @wolfgangcodes
+
 ## v1.0.3 - 2025-09-24
 
 - fix: fix instrumentation to get correct tracer (#602) | @beekhc

--- a/packages/honeycomb-opentelemetry-web/package-lock.json
+++ b/packages/honeycomb-opentelemetry-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@honeycombio/opentelemetry-web",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@honeycombio/opentelemetry-web",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.24.7",

--- a/packages/honeycomb-opentelemetry-web/package.json
+++ b/packages/honeycomb-opentelemetry-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honeycombio/opentelemetry-web",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Honeycomb OpenTelemetry Wrapper for Browser Applications",
   "repository": {
     "type": "git",

--- a/packages/honeycomb-opentelemetry-web/src/version.ts
+++ b/packages/honeycomb-opentelemetry-web/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.0.3';
+export const VERSION = '1.1.0';


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

Release `honeycomb-opentelemetry-web-v1.1.0`

## v1.1.0 - 2025-10-24

- feat: Add options metricExporters and disableDefaultMetricExporter (#605) | @sodabrew
- feat: expose session provider and OpenTelemetry APIs in CDN wrapper (#614) | @wolfgangcodes
- fix: remove redundant call to setGlobalTracerProvider as its set upon creation. (#615) | @wolfgangcodes