### PR TITLE
fix: Remove console log from onError handler

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/global-errors-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/global-errors-autoinstrumentation.ts
@@ -137,7 +137,6 @@ export class GlobalErrorsInstrumentation extends InstrumentationAbstract {
   onError = (event: ErrorEvent | PromiseRejectionEvent) => {
     const error: Error | undefined =
       'reason' in event ? event.reason : event.error;
-    console.log(this.applyCustomAttributesOnSpan);
     if (error) {
       recordException(error, {}, this.tracer, this.applyCustomAttributesOnSpan);
     }


### PR DESCRIPTION

## Which problem is this PR solving?

- Closes #621

## Short description of the changes

Removes stray console log statement from onError function.

## How to verify that this has the expected result

Throw an error in an instrument application and observe that no `undefined` value is logged.