### PR TITLE
feat: add page visibility state as a browser attribute

### DIFF
--- a/packages/honeycomb-opentelemetry-web/src/browser-attributes-span-processor.ts
+++ b/packages/honeycomb-opentelemetry-web/src/browser-attributes-span-processor.ts
@@ -22,7 +22,6 @@ export class BrowserAttributesSpanProcessor implements SpanProcessor {
 
   onStart(span: Span) {
     const { href, pathname, search, hash, hostname } = window.location;
-    console.log(document.visibilityState);
 
     span.setAttributes({
       [ATTR_BROWSER_WIDTH]: window.innerWidth,

--- a/packages/honeycomb-opentelemetry-web/src/browser-attributes-span-processor.ts
+++ b/packages/honeycomb-opentelemetry-web/src/browser-attributes-span-processor.ts
@@ -2,6 +2,7 @@ import { Span } from '@opentelemetry/api';
 import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import {
   ATTR_BROWSER_HEIGHT,
+  ATTR_BROWSER_PAGE_VISIBILITY,
   ATTR_BROWSER_WIDTH,
   ATTR_PAGE_HASH,
   ATTR_PAGE_HOSTNAME,
@@ -21,6 +22,7 @@ export class BrowserAttributesSpanProcessor implements SpanProcessor {
 
   onStart(span: Span) {
     const { href, pathname, search, hash, hostname } = window.location;
+    console.log(document.visibilityState);
 
     span.setAttributes({
       [ATTR_BROWSER_WIDTH]: window.innerWidth,
@@ -32,6 +34,8 @@ export class BrowserAttributesSpanProcessor implements SpanProcessor {
       [ATTR_PAGE_SEARCH]: search,
 
       [ATTR_URL_PATH]: pathname,
+
+      [ATTR_BROWSER_PAGE_VISIBILITY]: document.visibilityState,
     });
   }
 

--- a/packages/honeycomb-opentelemetry-web/src/semantic-attributes.ts
+++ b/packages/honeycomb-opentelemetry-web/src/semantic-attributes.ts
@@ -40,6 +40,12 @@ export const ATTR_BROWSER_WIDTH = 'browser.width';
  */
 export const ATTR_BROWSER_HEIGHT = 'browser.height';
 
+/**
+ * The visibility state of the page.
+ * @example "visible", "hidden"
+ */
+export const ATTR_BROWSER_PAGE_VISIBILITY = 'browser.page.visibility';
+
 // =============================================================================
 // Device Attributes
 // =============================================================================

--- a/packages/honeycomb-opentelemetry-web/test/browser-attributes-span-processor.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/browser-attributes-span-processor.test.ts
@@ -27,6 +27,7 @@ describe('BrowserAttributesSpanProcessor', () => {
 
     expect(finishedSpans[0].attributes).toEqual({
       'browser.width': 1024,
+      'browser.page.visibility': 'visible',
       'browser.height': 768,
       'page.hash': '#the-hash',
       'page.hostname': 'something-something.com',


### PR DESCRIPTION
## Which problem is this PR solving?
While investigating a separate issue with LCP metrics appearing inconsistent, we proposed the theory that pages are getting opened in the background, and realized that having page visibility data will be useful in general.

## Short description of the changes
Adds a new `browser.page.visibility` attribute that maps to [the `document.visiblityState` API](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState). 

## How to verify that this has the expected result
I tried writing a smoke test for this and didn't see any values appear, which I assume is because `document.visibilityState` doesn't apply in a headless browser 🙃 

I ran the examples locally and saw the attributes in the spans that got emitted.

I updated the unit tests as well so at least we have that.