### PR TITLE
feat: Add accurate span timing for Core Web Vitals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ junit.xml
 
 # example build outputs
 build
+tmp/**

--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -84,7 +84,7 @@ All vitals have the following attributes, they will each be namespaced by the na
 
 ```
 
-The event time is when the single largest layout shift contributing to the page's CLS score occurred. (performance.timeOrigin + metric.largestShiftTime)
+**Span Timing:** The span represents the CLS session window from the first layout shift to the last layout shift. The start time is when the first shift occurred, and the end time is when the last shift completed (last shift start time + duration). This accurately represents the time period during which layout shifts occurred.
 
 ### [Largest Contentful Paint](https://web.dev/articles/lcp) attributes
 
@@ -138,7 +138,7 @@ The event time is when the single largest layout shift contributing to the page'
 
 ```
 
-The event time is the start of the page load (performance.timeOrigin), the duration is equivalent to "lcp.value"
+**Span Timing:** The span represents the LCP loading lifecycle. The start time is when the LCP resource started loading (`loadTime`), and the end time is when the LCP element finished rendering (`renderTime`). The span duration represents the actual time to load and render the LCP element.
 
 ### [Interaction to Next Paint](https://web.dev/articles/optimize-inp) attributes
 
@@ -176,7 +176,7 @@ The event time is the start of the page load (performance.timeOrigin), the durat
 
 ```
 
-The event time is equal to the time the interaction began {[TODO] `attribution.eventTime + performance.timeOrigin`? or just `attribution.eventTime`}, the duration is equal to `inp.value`
+**Span Timing:** The span represents the user interaction timing. The start time is when the user interaction began (`interactionTime`), and the end time is when the next paint completed (`interactionTime + inp.value`). The span duration represents the total time from interaction to next paint.
 
 ### [First Contentful Paint](https://web.dev/articles/fcp) attributes
 
@@ -208,7 +208,7 @@ The event time is equal to the time the interaction began {[TODO] `attribution.e
 
 ```
 
-The event time is equal to the start of the page load, the duration is equal to `fcp.value`
+**Span Timing:** The span represents the time from when the user first sees the page to when the first contentful paint occurs. For normal pages, this starts at navigation start (`performance.timeOrigin`). For prerendered pages, this starts at activation time (`activationStart`) when the user actually sees the page. The end time is when FCP occurred. The span duration equals `fcp.value`.
 
 ### [Time to First Byte](https://web.dev/articles/ttfb) attributes
 
@@ -244,7 +244,7 @@ The event time is equal to the start of the page load, the duration is equal to 
 
 ```
 
-The event time is equal to the timeOrigin & the duration is equal to ttfb.value
+**Span Timing:** The span represents the time from when the user initiates the page load to when the first byte is received. For normal pages, this starts at navigation start (`performance.timeOrigin`). For prerendered pages, this starts at activation time (`activationStart`) when the user actually sees the page. The end time is when the first byte was received (`responseStart`). The span duration equals `ttfb.value`.
 
 ## Customization of event attributes
 

--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -84,7 +84,7 @@ All vitals have the following attributes, they will each be namespaced by the na
 
 ```
 
-**Span Timing:** The span represents the CLS session window from the first layout shift to the last layout shift. The start time is when the first shift occurred, and the end time is when the last shift completed (last shift start time + duration). This accurately represents the time period during which layout shifts occurred.
+**Span Timing:** The span represents the CLS session window from the first layout shift to the last layout shift. The start time is when the first shift occurred, and the end time is when the last shift occurred. `LayoutShift` entries always have `duration: 0` according to the [Layout Instability API specification](https://wicg.github.io/layout-instability/). When CLS = 0 (no shifts), a zero-duration span is created at time origin.
 
 ### [Largest Contentful Paint](https://web.dev/articles/lcp) attributes
 

--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -138,7 +138,7 @@ All vitals have the following attributes, they will each be namespaced by the na
 
 ```
 
-**Span Timing:** The span represents the LCP loading lifecycle. The start time is when the LCP resource started loading (`loadTime`), and the end time is when the LCP element finished rendering (`renderTime`). The span duration represents the actual time to load and render the LCP element.
+**Span Timing:** The span represents the LCP loading lifecycle. The start time is when the LCP resource started loading (`loadTime`), and the end time is when the LCP element rendering began (`renderTime`). For text-only LCP elements, `loadTime` is `0` since there is no resource to load. The span duration represents the time to load and render the LCP element.
 
 ### [Interaction to Next Paint](https://web.dev/articles/optimize-inp) attributes
 

--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -399,7 +399,6 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
   }
 
   private processPerformanceLongAnimationFrameTimingSpans(
-    parentPrefix: string,
     perfEntry?: PerformanceLongAnimationFrameTiming,
   ) {
     if (!perfEntry) return;
@@ -411,23 +410,19 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       { startTime: perfEntry.startTime },
       (span) => {
         span.setAttributes(loafAttributes);
-        this.processPerformanceScriptTimingSpans(
-          parentPrefix,
-          perfEntry.scripts,
-        );
+        this.processPerformanceScriptTimingSpans(perfEntry.scripts);
         span.end(perfEntry.startTime + perfEntry.duration);
       },
     );
   }
 
   private processPerformanceScriptTimingSpans(
-    parentPrefix: string,
     perfScriptEntries?: PerformanceScriptTiming[],
   ) {
     if (!perfScriptEntries) return;
     if (!perfScriptEntries?.length) return;
 
-    perfScriptEntries.map((scriptPerfEntry) => {
+    perfScriptEntries.forEach((scriptPerfEntry) => {
       this.tracer.startActiveSpan(
         scriptPerfEntry.name,
         { startTime: scriptPerfEntry.startTime },
@@ -613,10 +608,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
 
         if (includeTimingsAsSpans) {
           longAnimationFrameEntries.forEach((perfEntry) => {
-            this.processPerformanceLongAnimationFrameTimingSpans(
-              'inp',
-              perfEntry,
-            );
+            this.processPerformanceLongAnimationFrameTimingSpans(perfEntry);
           });
         }
         inpSpan.end(interactionTime + inpDuration);

--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -359,10 +359,6 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
     }
   }
 
-  private getAttrPrefix(name: string) {
-    return name.toLowerCase();
-  }
-
   private getAttributesForPerformanceLongAnimationFrameTiming(
     perfEntry: PerformanceLongAnimationFrameTiming,
   ) {

--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -606,51 +606,47 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
     const startTime = hrTime(interactionTime);
     const endTime = hrTime(interactionTime + inpDuration);
 
-    this.tracer.startActiveSpan(
-      name,
-      { startTime },
-      (inpSpan) => {
-        const inpAttributes = {
-          [ATTR_INP_ID]: inp.id,
-          [ATTR_INP_DELTA]: inp.delta,
-          [ATTR_INP_VALUE]: inp.value,
-          [ATTR_INP_RATING]: inp.rating,
-          [ATTR_INP_NAVIGATION_TYPE]: inp.navigationType,
-          [ATTR_INP_INPUT_DELAY]: inputDelay,
-          [ATTR_INP_INTERACTION_TARGET]: interactionTarget,
-          [ATTR_INP_INTERACTION_TIME]: interactionTime,
-          [ATTR_INP_INTERACTION_TYPE]: interactionType,
-          [ATTR_INP_LOAD_STATE]: loadState,
-          [ATTR_INP_NEXT_PAINT_TIME]: nextPaintTime,
-          [ATTR_INP_PRESENTATION_DELAY]: presentationDelay,
-          [ATTR_INP_PROCESSING_DURATION]: processingDuration,
-          [ATTR_INP_DURATION]: inpDuration,
-          // These will be deprecated in a future version
-          [ATTR_INP_ELEMENT]: interactionTarget,
-          [ATTR_INP_EVENT_TYPE]: interactionType,
-        };
+    this.tracer.startActiveSpan(name, { startTime }, (inpSpan) => {
+      const inpAttributes = {
+        [ATTR_INP_ID]: inp.id,
+        [ATTR_INP_DELTA]: inp.delta,
+        [ATTR_INP_VALUE]: inp.value,
+        [ATTR_INP_RATING]: inp.rating,
+        [ATTR_INP_NAVIGATION_TYPE]: inp.navigationType,
+        [ATTR_INP_INPUT_DELAY]: inputDelay,
+        [ATTR_INP_INTERACTION_TARGET]: interactionTarget,
+        [ATTR_INP_INTERACTION_TIME]: interactionTime,
+        [ATTR_INP_INTERACTION_TYPE]: interactionType,
+        [ATTR_INP_LOAD_STATE]: loadState,
+        [ATTR_INP_NEXT_PAINT_TIME]: nextPaintTime,
+        [ATTR_INP_PRESENTATION_DELAY]: presentationDelay,
+        [ATTR_INP_PROCESSING_DURATION]: processingDuration,
+        [ATTR_INP_DURATION]: inpDuration,
+        // These will be deprecated in a future version
+        [ATTR_INP_ELEMENT]: interactionTarget,
+        [ATTR_INP_EVENT_TYPE]: interactionType,
+      };
 
-        inpSpan.setAttributes(inpAttributes);
-        inp.entries.forEach((inpEntry) => {
-          this.addDataAttributes(
-            this.getElementFromNode(inpEntry.target),
-            inpSpan,
-            dataAttributes,
-            'inp',
-          );
+      inpSpan.setAttributes(inpAttributes);
+      inp.entries.forEach((inpEntry) => {
+        this.addDataAttributes(
+          this.getElementFromNode(inpEntry.target),
+          inpSpan,
+          dataAttributes,
+          'inp',
+        );
+      });
+      if (applyCustomAttributes) {
+        applyCustomAttributes(inp, inpSpan);
+      }
+
+      if (includeTimingsAsSpans) {
+        longAnimationFrameEntries.forEach((perfEntry) => {
+          this.processPerformanceLongAnimationFrameTimingSpans(perfEntry);
         });
-        if (applyCustomAttributes) {
-          applyCustomAttributes(inp, inpSpan);
-        }
-
-        if (includeTimingsAsSpans) {
-          longAnimationFrameEntries.forEach((perfEntry) => {
-            this.processPerformanceLongAnimationFrameTimingSpans(perfEntry);
-          });
-        }
-        inpSpan.end(endTime);
-      },
-    );
+      }
+      inpSpan.end(endTime);
+    });
   };
 
   onReportFCP = (fcp: FCPMetricWithAttribution, fcpOpts: VitalOpts = {}) => {

--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -279,7 +279,7 @@ export interface WebVitalsInstrumentationConfig extends InstrumentationConfig {
   lcp?: LcpVitalOpts;
 
   /** Config specific to CLS (Cumulative Layout Shift) */
-  cls?: VitalOpts;
+  cls?: ClsVitalOpts;
 
   /** Config specific to INP (Interaction to Next Paint) */
   inp?: InpVitalOpts;

--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -551,7 +551,12 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       lcpEntry,
     }: LCPAttribution = attribution;
 
-    const span = this.tracer.startSpan(name);
+    const startTime = lcpEntry?.loadTime || 0;
+    const endTime = lcpEntry?.renderTime || 0;
+
+    const span = this.tracer.startSpan(name, {
+      startTime,
+    });
     span.setAttributes({
       [ATTR_LCP_ID]: lcp.id,
       [ATTR_LCP_DELTA]: lcp.delta,
@@ -574,7 +579,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       applyCustomAttributes(lcp, span);
     }
 
-    span.end();
+    span.end(endTime);
   };
 
   onReportINP = (

--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -495,9 +495,8 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
     // Calculate session window timing
     const firstShiftTime = entries[0]?.startTime || 0;
     const lastShiftTime = entries[entries.length - 1]?.startTime || 0;
-    const lastShiftDuration = entries[entries.length - 1]?.duration || 0;
     const startTime = hrTime(firstShiftTime);
-    const endTime = hrTime(lastShiftTime + lastShiftDuration);
+    const endTime = hrTime(lastShiftTime);
 
     // Create parent span covering the session window period
     const span = this.tracer.startSpan(name, {

--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -551,8 +551,8 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       lcpEntry,
     }: LCPAttribution = attribution;
 
-    const startTime = lcpEntry?.loadTime || 0;
-    const endTime = lcpEntry?.renderTime || 0;
+    const startTime = hrTime(lcpEntry?.loadTime || 0);
+    const endTime = hrTime(lcpEntry?.renderTime || 0);
 
     const span = this.tracer.startSpan(name, {
       startTime,

--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -693,6 +693,7 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       dnsDuration,
       requestDuration,
       waitingDuration,
+      navigationEntry,
     }: TTFBAttribution = attribution;
     const attributes = {
       [ATTR_TTFB_ID]: ttfb.id,
@@ -711,13 +712,14 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       [ATTR_TTFB_CONNECTION_TIME]: connectionDuration,
       [ATTR_TTFB_REQUEST_TIME]: requestDuration,
     };
-
-    const span = this.tracer.startSpan(name);
+    const span = this.tracer.startSpan(name, {
+      startTime: navigationEntry?.startTime,
+    });
     span.setAttributes(attributes);
     if (applyCustomAttributes) {
       applyCustomAttributes(ttfb, span);
     }
-    span.end();
+    span.end(ttfb.value);
   };
 
   disable(): void {

--- a/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
@@ -311,6 +311,48 @@ const TTFB: TTFBMetricWithAttribution = {
     requestDuration: 300,
     cacheDuration: 100,
     connectionDuration: 200,
+    navigationEntry: {
+      activationStart: 0,
+      entryType: 'navigation',
+      name: '',
+      startTime: 0,
+      duration: 0,
+      initiatorType: 'navigation',
+      nextHopProtocol: '',
+      renderBlockingStatus: 'non-blocking',
+      deliveryType: '',
+      workerStart: 0,
+      redirectStart: 0,
+      redirectEnd: 0,
+      fetchStart: 0,
+      domainLookupStart: 0,
+      domainLookupEnd: 0,
+      connectStart: 0,
+      secureConnectionStart: 0,
+      connectEnd: 0,
+      requestStart: 0,
+      responseStart: 2500,
+      firstInterimResponseStart: 0,
+      responseEnd: 0,
+      transferSize: 0,
+      encodedBodySize: 0,
+      decodedBodySize: 0,
+      responseStatus: 200,
+      serverTiming: [],
+      unloadEventStart: 0,
+      unloadEventEnd: 0,
+      domInteractive: 0,
+      domContentLoadedEventStart: 0,
+      domContentLoadedEventEnd: 0,
+      domComplete: 0,
+      loadEventStart: 0,
+      loadEventEnd: 0,
+      type: 'navigate',
+      redirectCount: 0,
+      toJSON() {
+        return '';
+      },
+    } as PerformanceNavigationTiming,
   },
 };
 
@@ -691,6 +733,14 @@ describe('Web Vitals Instrumentation Tests', () => {
         '@honeycombio/instrumentation-web-vitals',
       );
       expect(span.attributes).toEqual(TTFBAttr);
+
+      // Verify explicit timing from actual browser events
+      // For normal (non-prerendered) pages: activationStart (0) to responseStart (2500ms)
+      const expectedStart = hrTime(0); // activationStart for normal page
+      const expectedEnd = hrTime(2500); // navigationEntry.responseStart
+
+      expect(span.startTime).toEqual(expectedStart);
+      expect(span.endTime).toEqual(expectedEnd);
     });
 
     it('should not create a span when disabled', () => {

--- a/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
@@ -6,6 +6,7 @@ import {
   TTFBMetricWithAttribution,
 } from 'web-vitals';
 import { WebVitalsInstrumentation } from '../src/web-vitals-autoinstrumentation';
+import { hrTime } from '@opentelemetry/core';
 
 import { setupTestExporter } from './test-helpers';
 
@@ -343,6 +344,15 @@ describe('Web Vitals Instrumentation Tests', () => {
         '@honeycombio/instrumentation-web-vitals',
       );
       expect(span.attributes).toEqual(LCPAttr);
+
+      // Verify explicit timing from actual browser events
+      // Performance entry times are DOMHighResTimeStamp (ms since time origin)
+      // which are converted to absolute HrTime using hrTime() helper
+      const expectedStart = hrTime(0); // lcpEntry.loadTime
+      const expectedEnd = hrTime(74.09999999403954); // lcpEntry.renderTime
+
+      expect(span.startTime).toEqual(expectedStart);
+      expect(span.endTime).toEqual(expectedEnd);
     });
 
     it('should not create a span when disabled', () => {

--- a/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
@@ -230,6 +230,57 @@ const FCP: FCPMetricWithAttribution = {
     timeToFirstByte: 200,
     firstByteToFCP: 400,
     loadState: 'complete',
+    fcpEntry: {
+      name: 'first-contentful-paint',
+      entryType: 'paint',
+      startTime: 2500,
+      duration: 0,
+      toJSON() {
+        return '';
+      },
+    },
+    navigationEntry: {
+      activationStart: 0,
+      entryType: 'navigation',
+      name: '',
+      startTime: 0,
+      duration: 0,
+      initiatorType: 'navigation',
+      nextHopProtocol: '',
+      renderBlockingStatus: 'non-blocking',
+      deliveryType: '',
+      workerStart: 0,
+      redirectStart: 0,
+      redirectEnd: 0,
+      fetchStart: 0,
+      domainLookupStart: 0,
+      domainLookupEnd: 0,
+      connectStart: 0,
+      secureConnectionStart: 0,
+      connectEnd: 0,
+      requestStart: 0,
+      responseStart: 200,
+      firstInterimResponseStart: 0,
+      responseEnd: 0,
+      transferSize: 0,
+      encodedBodySize: 0,
+      decodedBodySize: 0,
+      responseStatus: 200,
+      serverTiming: [],
+      unloadEventStart: 0,
+      unloadEventEnd: 0,
+      domInteractive: 0,
+      domContentLoadedEventStart: 0,
+      domContentLoadedEventEnd: 0,
+      domComplete: 0,
+      loadEventStart: 0,
+      loadEventEnd: 0,
+      type: 'navigate',
+      redirectCount: 0,
+      toJSON() {
+        return '';
+      },
+    } as PerformanceNavigationTiming,
   },
 };
 
@@ -596,6 +647,14 @@ describe('Web Vitals Instrumentation Tests', () => {
         '@honeycombio/instrumentation-web-vitals',
       );
       expect(span.attributes).toEqual(FCPAttr);
+
+      // Verify explicit timing from actual browser events
+      // For normal (non-prerendered) pages: activationStart (0) to fcpEntry.startTime (2500ms)
+      const expectedStart = hrTime(0); // activationStart for normal page
+      const expectedEnd = hrTime(2500); // fcpEntry.startTime
+
+      expect(span.startTime).toEqual(expectedStart);
+      expect(span.endTime).toEqual(expectedEnd);
     });
 
     it('should not create a span when disabled', () => {

--- a/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
@@ -447,6 +447,15 @@ describe('Web Vitals Instrumentation Tests', () => {
         '@honeycombio/instrumentation-web-vitals',
       );
       expect(span.attributes).toEqual(INPAttr);
+
+      // Verify explicit timing from actual browser events
+      // INP timing: interactionTime (10ms) to interactionTime + duration (1152ms)
+      const inpDuration = 42 + 600 + 500; // inputDelay + processingDuration + presentationDelay = 1142
+      const expectedStart = hrTime(10); // interactionTime
+      const expectedEnd = hrTime(10 + inpDuration); // interactionTime + inpDuration
+
+      expect(span.startTime).toEqual(expectedStart);
+      expect(span.endTime).toEqual(expectedEnd);
     });
 
     it('should create a include timings when enabled', () => {

--- a/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
@@ -22,7 +22,7 @@ const CLS: CLSMetricWithAttribution = {
       hadRecentInput: false,
       value: 0.1,
       sources: [],
-      duration: 0.2,
+      duration: 0,
       entryType: 'layout-shift',
       name: 'layout-shift',
       startTime: 100,
@@ -34,7 +34,7 @@ const CLS: CLSMetricWithAttribution = {
       hadRecentInput: true,
       value: 0.2,
       sources: [],
-      duration: 0.3,
+      duration: 0,
       entryType: 'layout-shift',
       name: 'layout-shift',
       startTime: 200,
@@ -52,7 +52,7 @@ const CLS: CLSMetricWithAttribution = {
       hadRecentInput: true,
       value: 0.2,
       sources: [],
-      duration: 0.3,
+      duration: 0,
       entryType: 'layout-shift',
       name: 'layout-shift',
       startTime: 0.1,
@@ -421,10 +421,8 @@ describe('Web Vitals Instrumentation Tests', () => {
       );
       expect(span.attributes).toMatchObject(CLSAttr);
 
-      // Verify explicit timing from actual browser events
-      // CLS uses session window: first shift (100ms) to last shift + duration (200.3ms)
-      const expectedStart = hrTime(100); // First entry startTime
-      const expectedEnd = hrTime(200.3); // Last entry startTime + duration
+      const expectedStart = hrTime(100);
+      const expectedEnd = hrTime(200);
 
       expect(span.startTime).toEqual(expectedStart);
       expect(span.endTime).toEqual(expectedEnd);


### PR DESCRIPTION
# feat: Add accurate span timing for Core Web Vitals

## Summary
Implements span timing for all Core Web Vitals metrics by using actual browser performance event timestamps instead of defaulting to time of report. This enables more accurate tracking of for CWV attribution, when they occurred and their  durations. Updated accompanying documentaion.

## Changes

### Implementation
- Use `hrTime()` helper from `@opentelemetry/core` to convert browser timestamps to OpenTelemetry high-resolution time
- Add explicit start/end times for all Web Vitals spans based on actual performance entries

### Per-Metric Changes

#### CLS (Cumulative Layout Shift)
- Session window timing: first shift → last shift
- Zero-duration span at time origin when CLS = 0 (perfect score)
- Added `dataAttributes` configuration (similar to LCP/INP)
- Added data attribute collection from largest shift source element

#### LCP (Largest Contentful Paint)
- Timing: `loadTime` → `renderTime`
- Represents actual resource loading and rendering lifecycle

#### INP (Interaction to Next Paint)
- Timing: `interactionTime` → `interactionTime + duration`
- Represents complete user interaction lifecycle

#### FCP (First Contentful Paint)
- Timing: navigation/activation start → FCP occurrence
- Prerendered page support via `activationStart`

#### TTFB (Time to First Byte)
- Timing: navigation/activation start → `responseStart`
- Prerendered page support via `activationStart`

## Breaking Changes
None - This is additive functionality that improves span timing accuracy.
