### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/frontend-observability
+* @honeycombio/agentic-observability


### PR DESCRIPTION
Update codeowners to the `agentic-observability` team.