### PR TITLE
ci: switch to OIDC auth for publishing to npmjs

### DIFF
--- a/.circleci/build.yml
+++ b/.circleci/build.yml
@@ -141,11 +141,11 @@ jobs:
     steps:
       - attach_workspace:
           at: ./
-      - run:
-          name: store npm auth token
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run: npm run build
-      - run: npm publish --access public
+      - run: |
+          export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+          [[ "${CIRCLE_TAG##*-v}" == *-* ]] && DIST_TAG="next" || DIST_TAG="latest"
+          npm publish --access public --tag "$DIST_TAG"
 
 workflows:
   build-web-distro:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@1.3.0
+  path-filtering: circleci/path-filtering@3.0.0
 
 parameters:
   base-path:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,9 @@
 
 ## Available Tag Prefixes
 
-We currently publish 2 packages from this repository. Each package is versioned separately, and may be released independently. We manage releases via git tags, and we use the following tags for each package:
+This repo can publish multiple packages.
+Each package is versioned separately, and may be released independently.
+We manage releases via git tags, and we use the following tags for each package:
 
 | package                                 | tag                                     |
 | --------------------------------------- | --------------------------------------- |

--- a/packages/honeycomb-opentelemetry-web/package-lock.json
+++ b/packages/honeycomb-opentelemetry-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@honeycombio/opentelemetry-web",
-  "version": "1.3.0",
+  "version": "1.3.1-pre.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@honeycombio/opentelemetry-web",
-      "version": "1.3.0",
+      "version": "1.3.1-pre.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.24.7",

--- a/packages/honeycomb-opentelemetry-web/package.json
+++ b/packages/honeycomb-opentelemetry-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honeycombio/opentelemetry-web",
-  "version": "1.3.0",
+  "version": "1.3.1-pre.0",
   "description": "Honeycomb OpenTelemetry Wrapper for Browser Applications",
   "repository": {
     "type": "git",

--- a/packages/honeycomb-opentelemetry-web/src/version.ts
+++ b/packages/honeycomb-opentelemetry-web/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.3.0';
+export const VERSION = '1.3.1-pre.0';


### PR DESCRIPTION
## Which problem is this PR solving?

npmjs and CircleCI support OIDC token exchange† now, so do that‡ instead of the old token style auth.

[† supported CI/CD](https://docs.npmjs.com/trusted-publishers#supported-cicd-providers)
[‡ CircleCI config](https://docs.npmjs.com/trusted-publishers#circleci-configuration)

## Short description of the changes

* Switch from `NPM_TOKEN` to `NPM_ID_TOKEN` retrieved via OIDC exchange per the instructions linked above.
* `[[ "${CIRCLE_TAG##*-v}" == *-* ]] && DIST_TAG="next" || DIST_TAG="latest"`
  * `##*-v` is a greedy strip of anything that comes before the last `-v` in a string.
  * This is: if a semantic version at the end of a tag contains a hyphen, it is a prerelease and should be published with the `next` tag, not `latest`.

```
honeycomb-opentelemetry-web-v1.3.0        -> 1.3.0         -> latest
honeycomb-opentelemetry-web-v1.3.0-alpha1 -> 1.3.0-alpha1  -> next
honeycomb-opentelemetry-voltron-v1.2.3    -> 1.2.3         -> latest
honeycomb-opentelemetry-voltron-v1.2.3-p0 -> 1.2.3-p0      -> next
v0.0.1                                    -> v0.0.1        -> latest
v0.4.0-rc.1                               -> v0.4.0-rc.1   -> next
```

## How to verify that this has the expected result

We'll bump a prerelease version in this branch and tag that commit to exercise the updated `publish_npm` job.