### PR TITLE
maint(deps): bump web-vitals from ^5.0.0 to ^6.0.1

### DIFF
--- a/packages/honeycomb-opentelemetry-web/.npmrc
+++ b/packages/honeycomb-opentelemetry-web/.npmrc
@@ -1,2 +1,2 @@
 ignore-scripts=true
-before=2025-09-08T00:00:00.000Z
+before=2026-07-28T00:00:00.000Z

--- a/packages/honeycomb-opentelemetry-web/package-lock.json
+++ b/packages/honeycomb-opentelemetry-web/package-lock.json
@@ -26,7 +26,7 @@
         "shimmer": "^1.2.1",
         "tracekit": "^0.4.7",
         "ua-parser-js": "^1.0.37",
-        "web-vitals": "^5.0.0"
+        "web-vitals": "^6.0.1"
       },
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.24.0",
@@ -15052,10 +15052,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
-      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
-      "license": "Apache-2.0"
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.0.1.tgz",
+      "integrity": "sha512-iF3+kno3Anlqi5fPVTQk9gYLfsCiL8P69Hof+AmZyVVx00E3e/BiGVvu+EsOy6jvTLqTKuiaRloPyw0JtdKbSw=="
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/packages/honeycomb-opentelemetry-web/package.json
+++ b/packages/honeycomb-opentelemetry-web/package.json
@@ -121,7 +121,7 @@
     "shimmer": "^1.2.1",
     "tracekit": "^0.4.7",
     "ua-parser-js": "^1.0.37",
-    "web-vitals": "^5.0.0"
+    "web-vitals": "^6.0.1"
   },
   "peerDependencies": {
     "@opentelemetry/auto-instrumentations-web": "^0.49.0",

--- a/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
+++ b/packages/honeycomb-opentelemetry-web/src/web-vitals-autoinstrumentation.ts
@@ -117,6 +117,19 @@ import { hrTime } from '@opentelemetry/core';
 
 type ApplyCustomAttributesFn = (vital: Metric, span: Span) => void;
 
+/**
+ * As of web-vitals v6, attribution navigation entries may be a
+ * PerformanceSoftNavigation, which has no timing fields; narrow to the
+ * hard-navigation entry. Uses an `in` check rather than `instanceof` so it
+ * also works in environments without the PerformanceNavigationTiming global.
+ */
+const getHardNavigationEntry = (
+  navigationEntry?: PerformanceNavigationTiming | PerformanceSoftNavigation,
+): PerformanceNavigationTiming | undefined =>
+  navigationEntry && 'responseStart' in navigationEntry
+    ? navigationEntry
+    : undefined;
+
 interface VitalOpts extends ReportOpts {
   /**
    * Callback function to add custom attributes to web vitals span.
@@ -603,8 +616,12 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
     }: INPAttribution = attribution;
 
     const inpDuration = inputDelay + processingDuration + presentationDelay;
-    const startTime = hrTime(interactionTime);
-    const endTime = hrTime(interactionTime + inpDuration);
+    // As of web-vitals v6, interactionTime may be undefined for small
+    // interactions reported without an event timing entry; fall back to
+    // the time origin (0), consistent with the other vitals handlers.
+    const interactionStart = interactionTime ?? 0;
+    const startTime = hrTime(interactionStart);
+    const endTime = hrTime(interactionStart + inpDuration);
 
     this.tracer.startActiveSpan(name, { startTime }, (inpSpan) => {
       const inpAttributes = {
@@ -662,8 +679,9 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       navigationEntry,
     }: FCPAttribution = attribution;
 
+    const hardNavigationEntry = getHardNavigationEntry(navigationEntry);
     // For prerendered pages, use activationStart; otherwise use navigation start (0)
-    const startTime = hrTime(navigationEntry?.activationStart || 0);
+    const startTime = hrTime(hardNavigationEntry?.activationStart || 0);
     // FCP entry's startTime is the raw timestamp from time origin
     const endTime = hrTime(fcpEntry?.startTime || 0);
 
@@ -704,10 +722,11 @@ export class WebVitalsInstrumentation extends InstrumentationAbstract {
       navigationEntry,
     }: TTFBAttribution = attribution;
 
+    const hardNavigationEntry = getHardNavigationEntry(navigationEntry);
     // For prerendered pages, use activationStart; otherwise use navigation start (0)
-    const startTime = hrTime(navigationEntry?.activationStart || 0);
+    const startTime = hrTime(hardNavigationEntry?.activationStart || 0);
     // TTFB responseStart is the raw timestamp from time origin
-    const endTime = hrTime(navigationEntry?.responseStart || 0);
+    const endTime = hrTime(hardNavigationEntry?.responseStart || 0);
 
     const attributes = {
       [ATTR_TTFB_ID]: ttfb.id,

--- a/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
+++ b/packages/honeycomb-opentelemetry-web/test/web-vitals-instrumentation.test.ts
@@ -17,6 +17,7 @@ const CLS: CLSMetricWithAttribution = {
   delta: 0.2,
   rating: 'needs-improvement',
   navigationType: 'back-forward',
+  navigationId: 1,
   entries: [
     {
       hadRecentInput: false,
@@ -88,6 +89,7 @@ const LCP: LCPMetricWithAttribution = {
   delta: 2500,
   rating: 'good',
   navigationType: 'back-forward',
+  navigationId: 1,
   entries: [],
   attribution: {
     target: 'div#lcp-element',
@@ -139,6 +141,7 @@ const performanceEventTiming: PerformanceEventTiming = {
   },
   duration: 0,
   interactionId: 0,
+  targetSelector: '',
   entryType: '',
   startTime: 0,
 };
@@ -151,6 +154,7 @@ const INP: INPMetricWithAttribution = {
   rating: 'good',
   entries: [],
   navigationType: 'back-forward',
+  navigationId: 1,
   attribution: {
     interactionTarget: 'div#inp-element',
     interactionType: 'pointer',
@@ -206,6 +210,7 @@ const INPWithTimings: INPMetricWithAttribution = {
   rating: 'good',
   entries: [],
   navigationType: 'back-forward',
+  navigationId: 1,
   attribution: {
     interactionTarget: 'div#inp-element',
     interactionType: 'pointer',
@@ -247,6 +252,7 @@ const FCP: FCPMetricWithAttribution = {
   delta: 2500,
   rating: 'good',
   navigationType: 'back-forward',
+  navigationId: 1,
   entries: [],
   attribution: {
     timeToFirstByte: 200,
@@ -325,6 +331,7 @@ const TTFB: TTFBMetricWithAttribution = {
   delta: 2500,
   rating: 'good',
   navigationType: 'back-forward',
+  navigationId: 1,
   entries: [],
   attribution: {
     waitingDuration: 100,


### PR DESCRIPTION
## Which problem is this PR solving?

Bumps `web-vitals` from `^5.0.0` to `^6.0.1` ([v6.0.0 release](https://github.com/GoogleChrome/web-vitals/releases/tag/v6.0.0), [upgrading-to-v6 guide](https://github.com/GoogleChrome/web-vitals/blob/main/docs/upgrading-to-v6.md)). v6 adds Soft Navigation support for the Web Vitals metrics, caps `requestIdleCallback` so metrics report even on busy pages, and ships source maps.

## Short description of the changes

- **`package.json` / `package-lock.json`**: `web-vitals` `^5.0.0` → `^6.0.1`.
- **`src/web-vitals-autoinstrumentation.ts`** — adaptations to v6 type changes:
  - TTFB & FCP: `attribution.navigationEntry` is now `PerformanceNavigationTiming | PerformanceSoftNavigation`; soft-navigation entries have no timing fields. Added a shared `getHardNavigationEntry()` helper that narrows via an `'responseStart' in entry` check (duck-typed rather than `instanceof`, so it also works in jsdom/test environments) before reading `activationStart`/`responseStart`. Behavior for hard navigations is unchanged; for soft-navigation entries the code falls back to `0`, same as when the entry is absent today.
  - INP: `attribution.interactionTime` is now optional (v6 can report small interactions that had no event timing entry, e.g. around bfcache restores); falls back to the time origin, consistent with the other handlers.
- **`test/web-vitals-instrumentation.test.ts`**: metric fixtures gain the now-required `navigationId`; the `PerformanceEventTiming` mock gains the now-required `targetSelector`.
- **`.npmrc`**: the registry `before` date was `2025-09-08`, which predates web-vitals v6 (published 2026-07-21) and makes `npm install` fail with `notarget`. Advanced it to `2026-07-28`. 👉 *Maintainer call-out: if you have a policy for how far this date should advance (e.g. a minimum-age quarantine), please adjust — this was the minimum move needed to resolve v6.0.1.*

Notes:
- This package doesn't use `INPAttribution.processedEventEntries`, so the v6 default flip of `includeProcessedEventEntries` to `false` has no effect here.
- Soft-navigation *reporting* remains opt-in on the web-vitals side; this PR only makes the instrumentation type-safe against the new union types. Exposing soft-nav options through `WebVitalsInstrumentationConfig` could be a nice follow-up.

## How to verify that this has the expected result

- `npm run build` — clean (was failing on the v6 types before the src changes).
- `npm test` — 17/17 suites, 159 passed / 1 skipped (same as before the bump).
- `npm run lint` — remaining errors are pre-existing in `examples/` (unresolved example deps), none in changed files.
