### PR TITLE
rel: Releasing honeycomb-opentelemetry-web-v1.4.0

### DIFF
--- a/packages/honeycomb-opentelemetry-web/CHANGELOG.md
+++ b/packages/honeycomb-opentelemetry-web/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.4.0 - 2026-08-25
+
 - feat: report Core Web Vitals for soft navigations (#656) | @wolfgangcodes
 - maint(deps): bump web-vitals from 5.1.0 to 6.1.0 in /packages/honeycomb-opentelemetry-web (#656) | @wolfgangcodes
 - maint: replace the `before` npm pin with `min-release-age` and pin Node via .nvmrc (#656) | @wolfgangcodes

--- a/packages/honeycomb-opentelemetry-web/README.md
+++ b/packages/honeycomb-opentelemetry-web/README.md
@@ -8,7 +8,7 @@ Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) in the browser. 
 
 Latest release:
 
-* built with OpenTelemetry JS [Stable v2.0.1](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.1), [Experimental v0.203.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.203.0), [API v1.9.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/api%2Fv1.9.0), [Semantic Conventions v1.36.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/semconv%2Fv1.34.0)
+* built with OpenTelemetry JS [Stable v2.0.1](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.1), [Experimental v0.203.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.203.0), [API v1.9.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/api%2Fv1.9.0), [Semantic Conventions v1.37.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/semconv%2Fv1.37.0)
 * compatible with OpenTelemetry Auto-Instrumentations for Web [~0.49.0](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-web-v0.49.0)
 
 This package sets up OpenTelemetry for tracing, using our recommended practices, including:

--- a/packages/honeycomb-opentelemetry-web/package-lock.json
+++ b/packages/honeycomb-opentelemetry-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@honeycombio/opentelemetry-web",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@honeycombio/opentelemetry-web",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.24.7",

--- a/packages/honeycomb-opentelemetry-web/package.json
+++ b/packages/honeycomb-opentelemetry-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honeycombio/opentelemetry-web",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Honeycomb OpenTelemetry Wrapper for Browser Applications",
   "repository": {
     "type": "git",

--- a/packages/honeycomb-opentelemetry-web/src/version.ts
+++ b/packages/honeycomb-opentelemetry-web/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.3.1';
+export const VERSION = '1.4.0';


### PR DESCRIPTION
Release prep for `honeycomb-opentelemetry-web-v1.4.0`
## Changelog

- feat: report Core Web Vitals for soft navigations (#656) | @wolfgangcodes
- maint(deps): bump web-vitals from 5.1.0 to 6.1.0 in /packages/honeycomb-opentelemetry-web (#656) | @wolfgangcodes
- maint: replace the `before` npm pin with `min-release-age` and pin Node via .nvmrc (#656) | @wolfgangcodes