### PR TITLE
maint: remove the dead script tag from the collector example

### DIFF
--- a/packages/honeycomb-opentelemetry-web/CHANGELOG.md
+++ b/packages/honeycomb-opentelemetry-web/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- maint: remove the dead script tag from the collector example (#670) | @wolfgangcodes
+
 ## v1.4.0 - 2026-08-25
 
 - feat: report Core Web Vitals for soft navigations (#656) | @wolfgangcodes

--- a/packages/honeycomb-opentelemetry-web/examples/custom-with-collector-ts/src/index.html
+++ b/packages/honeycomb-opentelemetry-web/examples/custom-with-collector-ts/src/index.html
@@ -24,8 +24,6 @@
       <span id="dadJokeText"></span>
     </div>
   </section>
-  <!-- Scripts here. Don't remove ↓ -->
-  <script type="module" src="dist/index.js"></script>
 </body>
 
 </html>

--- a/packages/honeycomb-opentelemetry-web/smoke-tests/smoke-e2e.bats
+++ b/packages/honeycomb-opentelemetry-web/smoke-tests/smoke-e2e.bats
@@ -82,7 +82,6 @@ teardown_file() {
   result=$(span_attributes_for ${DOCUMENT_LOAD_SCOPE} | jq "select(.key == \"SampleRate\").value.intValue")
   assert_equal "$result" '"1"
 "1"
-"1"
 "1"'
 }
 
@@ -95,10 +94,9 @@ teardown_file() {
 "click"
 "click"'
 }
-@test "Auto instrumentation produces 4 document load spans" {
+@test "Auto instrumentation produces 3 document load spans" {
   result=$(span_names_for ${DOCUMENT_LOAD_SCOPE})
   assert_equal "$result" '"documentFetch"
-"resourceFetch"
 "resourceFetch"
 "documentLoad"'
 }


### PR DESCRIPTION
## Which problem is this PR solving?

`examples/custom-with-collector-ts` logs a `404 (Not Found)` in the browser console on every page load.

`src/index.html` hardcodes:

```html
<script type="module" src="dist/index.js"></script>
```

but webpack emits `bundle.js`, and `HtmlWebpackPlugin` already injects the correct tag. So the page loads the real bundle *and* requests a file that has never existed. The path is wrong twice over — wrong directory and wrong filename.

The tag dates to #203 (2024-08-01), when the repo moved to multiple packages.

## Short description of the changes

Remove the dead tag. The injected `<script defer src="bundle.js">` is the only one needed.

Also update two smoke test assertions, which were pinned to the buggy behaviour. The 404 request was itself producing one of the two `resourceFetch` spans the bats suite expected, so removing it drops the document-load scope from 4 spans to 3:

| | before | after |
|---|---|---|
| `documentFetch` | 1 | 1 |
| `resourceFetch` | 2 (one of them the 404) | 1 |
| `documentLoad` | 1 | 1 |

`Auto instrumentation produces 4 document load spans` becomes `...3 document load spans`, and the `SampleRate` assertion over the same scope drops from four values to three.

## How to verify

```
npm run build
cd examples/custom-with-collector-ts && npm start
```

Before — served HTML carries both tags, console shows the 404:

```
GET http://localhost:1234/bundle.js       [200]
GET http://localhost:1234/dist/index.js   [404]
```

After — one tag, no 404:

```
GET http://localhost:1234/           [200]
GET http://localhost:1234/bundle.js  [200]
POST http://localhost:4318/v1/traces [200]
```

Verified in Chrome against a local OTLP receiver: the app still loads and still exports telemetry, and the document-load scope emits exactly `documentFetch`, `resourceFetch`, `documentLoad`.

## Notes

Checked every other example while I was in here; no equivalent problem.

- `hello-world-cjs`, `hello-world-custom-exporter`, `hello-world-web` build to `build/bundle.js` with esbuild and reference exactly that.
- `hello-world-cdn` uses `../dist/umd/index.js`, which looks wrong but resolves fine — browsers clamp `../` at the server root, so it lands on `/dist/umd/index.js` (200). Left alone since it works, though `./dist/umd/index.js` would say what it means.

Every example still requests `/favicon.ico` and gets a 404. That's the browser asking on its own, not the page, so it's out of scope here.